### PR TITLE
Release v24.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 24.0.0
+
+NOTES:
+
+* Change versioning policy: `v4.14.0-CROCX` => semver started from `v24.0.0`
+
+FEATURES:
+
+* **New Data Source:** `aws_ec2_transit_gateway`
+* **New Data Source:** `aws_ec2_transit_gateway_route_table`
+* **New Data Source:** `aws_ec2_transit_gateway_route_tables`
+* **New Data Source:** `aws_ec2_transit_gateway_vpc_attachment`
+* **New Data Source:** `aws_ec2_transit_gateway_vpc_attachments`
+* **New Resource:** `aws_ec2_transit_gateway`
+* **New Resource:** `aws_ec2_transit_gateway_route`
+* **New Resource:** `aws_ec2_transit_gateway_route_table`
+* **New Resource:** `aws_ec2_transit_gateway_route_table_association`
+* **New Resource:** `aws_ec2_transit_gateway_route_table_propagation`
+* **New Resource:** `aws_ec2_transit_gateway_vpc_attachment`
+
 ## 4.14.0-CROC10
 
 FEATURES:

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/hashicorp/terraform-provider-aws
 
 go 1.17
 
-replace github.com/aws/aws-sdk-go => github.com/C2Devel/aws-sdk-go v1.44.10-CROC6
+replace github.com/aws/aws-sdk-go => github.com/C2Devel/aws-sdk-go v1.44.10-CROC7
 
 require (
 	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/C2Devel/aws-sdk-go v1.44.10-CROC6 h1:IAkIGxqdInYwRaheS+uS0pm8PhftZbDi9eJEUHOvjr8=
-github.com/C2Devel/aws-sdk-go v1.44.10-CROC6/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
+github.com/C2Devel/aws-sdk-go v1.44.10-CROC7 h1:GzeDvcGIB3rvYXSfOFNroC7f64yoH51JtTWC6zZjRAA=
+github.com/C2Devel/aws-sdk-go v1.44.10-CROC7/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=


### PR DESCRIPTION
NOTES:

* Change versioning policy: `v4.14.0-CROCX` => semver started from `v24.0.0`

FEATURES:

* **New Data Source:** `aws_ec2_transit_gateway`
* **New Data Source:** `aws_ec2_transit_gateway_route_table`
* **New Data Source:** `aws_ec2_transit_gateway_route_tables`
* **New Data Source:** `aws_ec2_transit_gateway_vpc_attachment`
* **New Data Source:** `aws_ec2_transit_gateway_vpc_attachments`
* **New Resource:** `aws_ec2_transit_gateway`
* **New Resource:** `aws_ec2_transit_gateway_route`
* **New Resource:** `aws_ec2_transit_gateway_route_table`
* **New Resource:** `aws_ec2_transit_gateway_route_table_association`
* **New Resource:** `aws_ec2_transit_gateway_route_table_propagation`
* **New Resource:** `aws_ec2_transit_gateway_vpc_attachment`