### PR TITLE
route53: make some parameters unsupported

### DIFF
--- a/internal/service/route53/record.go
+++ b/internal/service/route53/record.go
@@ -32,7 +32,7 @@ var (
 )
 
 func ResourceRecord() *schema.Resource {
-	//lintignore:R011
+	// lintignore:R011
 	return &schema.Resource{
 		Create: resourceRecordCreate,
 		Read:   resourceRecordRead,
@@ -652,16 +652,13 @@ func findRecord(d *schema.ResourceData, meta interface{}) (*route53.ResourceReco
 	// If this isn't a Weighted, Latency, Geo, or Failover resource with
 	// a SetIdentifier we only need to look at the first record in the response since there can be
 	// only one
-	maxItems := "1"
+	// maxItems := "1"
 	// if recordSetIdentifier != "" {
 	// 	maxItems = "100"
 	// }
 
 	lopts := &route53.ListResourceRecordSetsInput{
-		HostedZoneId:    aws.String(CleanZoneID(zone)),
-		StartRecordName: aws.String(recordName),
-		StartRecordType: aws.String(recordType),
-		MaxItems:        aws.String(maxItems),
+		HostedZoneId: aws.String(CleanZoneID(zone)),
 	}
 
 	log.Printf("[DEBUG] List resource records sets for zone: %s, opts: %s",

--- a/internal/service/route53/zone_data_source.go
+++ b/internal/service/route53/zone_data_source.go
@@ -151,7 +151,7 @@ func dataSourceZoneRead(d *schema.ResourceData, meta interface{}) error {
 				}
 			}
 		}
-		if *resp.IsTruncated {
+		if resp.IsTruncated != nil && *resp.IsTruncated {
 			nextMarker = resp.NextMarker
 		} else {
 			allHostedZoneListed = true

--- a/website/docs/r/route53_record.html.markdown
+++ b/website/docs/r/route53_record.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the record.
 * `type` - (Required) The record type. Valid values are `A`, `AAAA`, `CNAME`, `MX`, `NS`, `PTR`, `SRV` and `TXT`.
 * `ttl` - (Required) The TTL of the record.
-* `records` - (Required) A string list of records. To specify a single record value longer than 255 characters such as a TXT record for DKIM, add `\"\"` inside the Terraform configuration string (e.g., `"first255characters\"\"morecharacters"`).
+* `records` - (Required) A string list of records. To specify a single record value longer than 255 characters such as a TXT record for DKIM, add `\" \"` inside the Terraform configuration string to split characters into multiple text strings (e.g., `"first255characters\" \"next255characters"`).
 * `allow_overwrite` - (Optional) Allow creation of this record in Terraform to overwrite an existing record, if any. This does not affect the ability to update the record in Terraform and does not prevent other resources within Terraform or manual Route 53 changes outside Terraform from overwriting this record. `false` by default. This configuration is not recommended for most environments.
 
 ## Attributes Reference


### PR DESCRIPTION
ENHANCEMENTS:
- resources/aws_route53_record: Remove the `StartRecordName`,  `StartRecordType`, `MaxItems` parameters as it is not supported.
- resources/aws_route53_record: Fix description in documentation about records that contain more than 255 characters.
- datasource/aws_route53_zone: Make the `IsTruncated` parameter optional as it is not supported.