### PR TITLE
rockit rebranding

### DIFF
--- a/docs/c2/README.md
+++ b/docs/c2/README.md
@@ -1,7 +1,7 @@
-# Terraform C2 Provider
+# Terraform Rockit Cloud Provider
 
 Адаптация [Terraform AWS Provider](https://github.com/hashicorp/terraform-provider-aws) от **HashiCorp**
-под **Облако КРОК** (C2).
+под **Rockit Cloud**.
 
 | Upstream Name | Upstream Version |
 |------|---------|
@@ -43,14 +43,14 @@
 ресурсами некоего сервиса (например, облака или БД) через его API. Для каждого ресурса в провайдер добавляется
 схема и CRUD операции. Информация об API предоставляется в виде отдельного модуля.
 
-**Terraform C2 Provider** реализуется на базе **Terraform AWS Provider**.
+**Terraform Rockit Cloud Provider** реализуется на базе **Terraform AWS Provider**.
 Также создан форк модуля с AWS API: [C2Devel/aws-sdk-go](https://github.com/C2Devel/aws-sdk-go).
 
 Для публикации провайдера в официальном [terraform registry](https://registry.terraform.io/) под новым именем
 (ранее - *aws*) форк переименован в  
-*terraform-provider-croccloud*.
+*terraform-provider-rockitcloud*.
 
-Опубликованный провайдер: https://registry.terraform.io/providers/C2Devel/croccloud
+Опубликованный провайдер: https://registry.terraform.io/providers/C2Devel/rockitcloud
 
 ## Начало работы
 
@@ -59,7 +59,7 @@
 Клонирование репозитория и сборка провайдера:
 
 ```
-$ git clone git@github.com:C2Devel/terraform-provider-croccloud.git && cd terraform-provider-croccloud
+$ git clone git@github.com:C2Devel/terraform-provider-rockitcloud.git && cd terraform-provider-rockitcloud
 ...
 $ make build
 ```
@@ -80,10 +80,10 @@ $ ls $GOPATH/bin/terraform-provider-aws
 Для сборки проекта также можно использовать команду:
 
 ```
-$ go build -o terraform-provider-croccloud
+$ go build -o terraform-provider-rockitcloud
 ```
 
-Артефакт `terraform-provider-croccloud` будет создан в директории запуска.
+Артефакт `terraform-provider-rockitcloud` будет создан в директории запуска.
 
 ### Установка линтеров
 
@@ -262,7 +262,7 @@ $ make docscheck
 **Важно!** Не допускается обновление уже выпущенных версий, т.к. могут возникнуть проблемы со скачиванием провайдера
 из terraform registry.
 
-Стартовая версия: **v24.0.0**
+Стартовая версия: **v24.1.0**
 
 ### Релиз
 
@@ -302,13 +302,13 @@ $ make docscheck
 
 8. **Опционально.** Если на шаге 2 **не** была включена автопубликация (`release.draft: true`):
    создание релиза на github и загрузка артефактов:
-    - `dist/terraform-provider-croccloud_{VERSION}_{OS}_{ARCH}.zip`
+    - `dist/terraform-provider-rockitcloud_{VERSION}_{OS}_{ARCH}.zip`
         - Для всех архитектур и ОС.
-    - `dist/terraform-provider-croccloud_{VERSION}_SHA256SUMS`
-    - `dist/terraform-provider-croccloud_{VERSION}_SHA256SUMS.sig`
-    - `terraform-provider-croccloud_{VERSION}_manifest.json`
+    - `dist/terraform-provider-rockitcloud_{VERSION}_SHA256SUMS`
+    - `dist/terraform-provider-rockitcloud_{VERSION}_SHA256SUMS.sig`
+    - `terraform-provider-rockitcloud_{VERSION}_manifest.json`
         - Файл создается вручную:
-        - `cp terraform-registry-manifest.json terraform-provider-croccloud_{VERSION}_manifest.json`
+        - `cp terraform-registry-manifest.json terraform-provider-rockitcloud_{VERSION}_manifest.json`
 
 ## Публикация провайдера в официальном terraform registry
 
@@ -342,14 +342,14 @@ $ make docscheck
 **Важно!** Terraform не позволяет самостоятельно удалять опубликованный провайдер или одну из его версий.
 Не допускается обновление уже выпущенных версий.
 
-Опубликованный провайдер: https://registry.terraform.io/providers/C2Devel/croccloud
+Опубликованный провайдер: https://registry.terraform.io/providers/C2Devel/rockitcloud
 
 ## Публикация провайдера в private terraform registry
 
 Terraform registry может быть организован в виде s3 бакета.
 
 **Важно!** У бакета должен быть настроен доступ по https
-([инструкция от CROC](https://docs.cloud.croc.ru/en/services/object_storage/instructions.html#filestorage-https-for-website-buckets)).
+([инструкция](https://docs.cloud.croc.ru/en/services/object_storage/instructions.html#filestorage-https-for-website-buckets)).
 При включении web-доступа в качестве индексной страницы требуется указать `index.json`.
 
 Согласно [описанию](https://www.terraform.io/internals/provider-registry-protocol) протокола,
@@ -364,12 +364,12 @@ terraform registry содержит в себе файлы с версиями �
 
 providers/
 |-- c2devel/                                       # разработчик
-     |-- croccloud/                                # имя провайдера
-          |-- 1.0.0-CROC0/
+     |-- rockitcloud/                                # имя провайдера
+          |-- 1.0.0/
           |    |-- download/
           |         |-- linux/
           |         |    |-- amd64/
-          |         |    |    |-- index.json       # метаинформация для сборки 1.0.0-CROC0_linux_amd64
+          |         |    |    |-- index.json       # метаинформация для сборки 1.0.0_linux_amd64
           |         |    |-- ...
           |         |-- ...
           |    
@@ -391,10 +391,10 @@ providers/
 Исходный вид файла с версиями провайдера:
 
 ```
-# providers/c2devel/croccloud/versions/index.json
+# providers/c2devel/rockitcloud/versions/index.json
 
 {
-    "id": "c2devel/croccloud",
+    "id": "c2devel/rockitcloud",
     "versions": [],
     "warnings": null
 }
@@ -415,28 +415,28 @@ providers/
 1. Получение версий провайдера. В файле должна присутствовать загружаемая версия
 
    ```
-   $ curl https://registry.terraform.io/v1/providers/c2devel/croccloud/versions --output versions.json
+   $ curl https://registry.terraform.io/v1/providers/c2devel/rockitcloud/versions --output versions.json
    ```
 
    В блоке `versions.<version>.platforms` указаны архитектуры и ОС, под которые версия собиралась.
 2. Получение метаинформации для выбранных сборок провайдера
 
    ```
-   $ curl https://registry.terraform.io/v1/providers/c2devel/croccloud/<version>/download/<os>/<arch> --output <version>_<os>_<arch>.json
+   $ curl https://registry.terraform.io/v1/providers/c2devel/rockitcloud/<version>/download/<os>/<arch> --output <version>_<os>_<arch>.json
    ```
 
 3. **Опционально.** Сохранение артефактов в собственное хранилище.
    Артефакты можно скачать по ссылкам в метаинформации или скопировать из директории `dist/`:
-   - `dist/terraform-provider-croccloud_{VERSION}_{OS}_{ARCH}.zip`
+   - `dist/terraform-provider-rockitcloud_{VERSION}_{OS}_{ARCH}.zip`
       - Для всех архитектур и ОС.
-   - `dist/terraform-provider-croccloud_{VERSION}_SHA256SUMS`
-   - `dist/terraform-provider-croccloud_{VERSION}_SHA256SUMS.sig`
+   - `dist/terraform-provider-rockitcloud_{VERSION}_SHA256SUMS`
+   - `dist/terraform-provider-rockitcloud_{VERSION}_SHA256SUMS.sig`
 
 4. **Опционально.** Если был выполнен шаг 3: обновление ссылок в метаинформации
 5. Обновление s3 бакета:
-   - обновление файла с версиями: `version.json` -> `providers/c2devel/croccloud/versions/index.json`
+   - обновление файла с версиями: `version.json` -> `providers/c2devel/rockitcloud/versions/index.json`
    - загрузка метаинформации для сборок версии:  
-     `<version>_<os>_<arch>.json` -> `providers/c2devel/croccloud/<version>/download/<os>/<arch>/index.json`
+     `<version>_<os>_<arch>.json` -> `providers/c2devel/rockitcloud/<version>/download/<os>/<arch>/index.json`
    **Важно!** Файлы должны быть загружены с mime-типом "application/json". Для файлов должен быть
    открыт доступ на чтение без аутентификации.
 
@@ -452,7 +452,7 @@ providers/
 **Важно!** Файл с версиями в s3 бакете будет приведен к виду официального registry.
 
 Для запуска скрипта требуется установка и настройка утилиты [s3cmd](https://s3tools.org/s3cmd)
-([инструкция от CROC](https://docs.cloud.croc.ru/ru/api/tools/s3cmd.html?highlight=s3cmd))
+([инструкция](https://docs.cloud.croc.ru/ru/api/tools/s3cmd.html?highlight=s3cmd))
 и созданный s3 бакет (см. [структура s3 бакета](#структура-s3-бакета)).
 
 Переменные окружения скрипта:
@@ -460,7 +460,7 @@ providers/
 - `TF_REGISTRY_URL` - url terraform registry, по умолчанию: `"https://registry.terraform.io/"`
 - `S3_REGISTRY_URL` - url s3 registry, обязательно
 - `S3_BUCKET_NAME` - имя бакета, обязательно
-- `PROVIDER_NAME` - имя провайдера, по умолчанию: `"c2devel/croccloud"`
+- `PROVIDER_NAME` - имя провайдера, по умолчанию: `"c2devel/rockitcloud"`
 - `S3_BACKUP_DIR` - директория для бэкапа бакета, опционально. Если директория не указана,
    бэкап сделан не будет
 
@@ -474,11 +474,11 @@ $ ./update-s3-registry.sh
 
 ## Использование провайдера
 
-Провайдер в terraform registry: https://registry.terraform.io/providers/C2Devel/croccloud
+Провайдер в terraform registry: https://registry.terraform.io/providers/C2Devel/rockitcloud
 
 Примеры использования **Terraform** для C2: [C2Devel/terraform-examples](https://github.com/C2Devel/terraform-examples)
 
-Конфигурация провайдера **C2Devel/croccloud** после его публикации в официальном terraform registry:
+Конфигурация провайдера **C2Devel/rockitcloud** после его публикации в официальном terraform registry:
 
 ```
 # provider.tf
@@ -487,8 +487,8 @@ terraform {
   required_providers {
     aws = {
       # case-insensistive
-      source = "c2devel/croccloud"
-      version = "4.14.0-CROC1"
+      source = "c2devel/rockitcloud"
+      version = "24.1.0"
     }
   }
 }
@@ -499,11 +499,11 @@ provider "aws" {
 ```
 
 **Важно!** В конфигурации в качестве имени провадйера используется `aws`, т.к. сохранена схема
-именования terraform ресурсов: **aws_***. Если используется другое имя (например, `croccloud`),
+именования terraform ресурсов: **aws_***. Если используется другое имя (например, `rockitcloud`),
 **Terraform** автоматически попытается загрузить провайдер **hashicorp/aws**.
 
 Если провайдер опубликован в s3 бакете, в поле `source` добавляется url бакета без схемы. Например,  
-`tf-registry.croc.ru/c2devel/croccloud`.
+`tf-registry.rockitcloud.ru/c2devel/rockitcloud`.
 
 ### Локальная сборка
 
@@ -544,6 +544,6 @@ $ export TF_CLI_CONFIG_FILE=<path-to-dev.tfrc>
 2. Доработка acceptance тестов для запуска на C2
 3. Использовать в `make build` команду `go build` вместо `go install` для того,
    чтобы иметь возможность задать имя артефакта
-4. Обновить схему именования ресурсов: **aws_*** -> **croccloud_***,
-   чтобы иметь возможность использовать в конфигурации в качестве имени провайдера `croccloud`.
+4. Обновить схему именования ресурсов: **aws_*** -> **rockitcloud_***,
+   чтобы иметь возможность использовать в конфигурации в качестве имени провайдера `rockitcloud`.
    Потребуется проверка совместимости с aws конфигурациями

--- a/internal/service/ec2/ec2_ami.go
+++ b/internal/service/ec2/ec2_ami.go
@@ -250,7 +250,7 @@ func ResourceAMI() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				// FIXME: Enable forced replacement on new value
-				// when CROC Cloud API supports the `SriovNetSupport` parameter
+				// when C2 API supports the `SriovNetSupport` parameter
 				ForceNew: false,
 				Default:  "simple",
 			},
@@ -434,7 +434,7 @@ func resourceAMIRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags := KeyValueTags(image.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
-	//lintignore:AWSR002
+	// lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %w", err)
 	}

--- a/internal/service/ec2/ec2_launch_template.go
+++ b/internal/service/ec2/ec2_launch_template.go
@@ -1024,7 +1024,7 @@ func resourceLaunchTemplateRead(d *schema.ResourceData, meta interface{}) error 
 
 	tags := KeyValueTags(lt.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
-	//lintignore:AWSR002
+	// lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %w", err)
 	}
@@ -1977,7 +1977,7 @@ func expandLaunchTemplateInstanceNetworkInterfaceSpecificationRequest(tfMap map[
 		apiObject.Ipv6Prefixes = expandIPv6PrefixSpecificationRequests(v.List())
 	}
 
-	// CROC Cloud API does not support `NetworkCardIndex` parameter
+	// С2 API does not support `NetworkCardIndex` parameter
 	// if v, ok := tfMap["network_card_index"].(int); ok {
 	// 	apiObject.NetworkCardIndex = aws.Int64(int64(v))
 	// }

--- a/internal/service/paas/README.md
+++ b/internal/service/paas/README.md
@@ -1,1 +1,1 @@
-# Terraform CROC Cloud Provider PaaS Package
+# Terraform Rockit Cloud Provider PaaS Package

--- a/scripts/update-s3-registry.sh
+++ b/scripts/update-s3-registry.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 TF_REGISTRY_URL=${TF_REGISTRY_URL:-"https://registry.terraform.io/"}
 S3_REGISTRY_URL=${S3_REGISTRY_URL:-}
 S3_BUCKET_NAME=${S3_BUCKET_NAME:-}
-PROVIDER_NAME=${PROVIDER_NAME:-"c2devel/croccloud"}
+PROVIDER_NAME=${PROVIDER_NAME:-"c2devel/rockitcloud"}
 
 S3_BACKUP_DIR=${S3_BACKUP_DIR:-}
 TMP_DIR="/tmp/"

--- a/website/docs/d/ami.html.markdown
+++ b/website/docs/d/ami.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
-page_title: "CROC Cloud: aws_ami"
+page_title: "aws_ami"
 description: |-
   Get information on an Amazon Machine Image (AMI).
 ---

--- a/website/docs/d/ami.html.markdown
+++ b/website/docs/d/ami.html.markdown
@@ -30,21 +30,20 @@ data "aws_ami" "example" {
 
 ## Argument Reference
 
-* `owners` - (Required) List of image owners to limit search. At least 1 value must be specified.
-  Valid values: the CROC Cloud project ID or `self`.
+* `owners` - (Required) List of image owners to limit search. At least one value must be specified.
+  Valid items are the project ID (`project@customer`) or `self`.
 * `most_recent` - (Optional) If more than one result is returned, use the most recent image.
-* `executable_users` - (Optional) Limit search to project with *explicit* launch permission on
- the image. Valid items are the CROC Cloud project ID or `self`.
+* `executable_users` - (Optional) Limit search to project with *explicit* launch permission on the image.
+  Valid items are the project ID (`project@customer`), `all` or `self`.
 
 * `filter` - (Optional) One or more name/value pairs to filter.
 
 For more information about filtering, see the [EC2 API documentation][describe-images].
 
-* `name_regex` - (Optional) A regex string to apply to the image list returned
-by CROC Cloud. This allows more advanced filtering not supported from the CROC Cloud API. This
-filtering is done locally on what CROC Cloud returns, and could have a performance
-impact if the result is large. It is recommended to combine this with other
-options to narrow down the list CROC Cloud returns.
+* `name_regex` - (Optional) A regex string to apply to the image list returned by the EC2 API.
+  This allows more advanced filtering. It is done locally on what the EC2 API returns,
+  and could have a performance impact if the result is large.
+  It is recommended to combine this with other options to narrow down the list the EC2 API returns.
 
 ~> **NOTE:** If more or less than a single match is returned by the search,
 Terraform will fail. Ensure that your search is specific enough to return
@@ -53,8 +52,9 @@ you want to match multiple images, use the [`aws_ami_ids`](ami_ids.html.markdown
 
 ## Attributes Reference
 
-`id` is set to the ID of the found image. In addition, the following attributes
-are exported:
+`id` is set to the ID of the found image.
+
+In addition, the following attributes are exported:
 
 ~> **NOTE:** Some values are not always set and may not be available for
 interpolation.
@@ -76,7 +76,7 @@ interpolation.
 * `image_owner_alias` -  The alias of the image owner name.
 * `image_type` - The type of image.
 * `name` - The name of the image that was provided during image creation.
-* `owner_id` - The CROC Cloud project ID.
+* `owner_id` - The project ID.
 * `platform` - The value is Windows for `Windows` images; otherwise blank.
 * `public` - `true` if the image has public launch permissions.
 * `root_device_name` - The device name of the root device.

--- a/website/docs/d/ami.html.markdown
+++ b/website/docs/d/ami.html.markdown
@@ -89,7 +89,7 @@ interpolation.
 * `virtualization_type` - The type of virtualization of the image (ie: `hvm`).
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `boot_mode` - The boot mode of the image. Always `""`.
 * `creation_date` - The date and time the image was created. Always `""`.

--- a/website/docs/d/ami_ids.html.markdown
+++ b/website/docs/d/ami_ids.html.markdown
@@ -20,20 +20,19 @@ data "aws_ami_ids" "example" {
 
 ## Argument Reference
 
-* `owners` - (Required) List of image owners to limit search. At least 1 value must be specified.
-  Valid values: the CROC Cloud project ID or `self`.
-* `executable_users` - (Optional) Limit search to project with *explicit* launch permission on
- the image. Valid items are the CROC Cloud project ID or `self`.
+* `owners` - (Required) List of image owners to limit search. At least one value must be specified.
+  Valid items are the project ID (`project@customer`) or `self`.
+* `executable_users` - (Optional) Limit search to project with *explicit* launch permission on the image.
+  Valid items are the project ID (`project@customer`), `all` or `self`.
 
 * `filter` - (Optional) One or more name/value pairs to filter.
 
 For more information about filtering, see the [EC2 API documentation][describe-images].
 
-* `name_regex` - (Optional) A regex string to apply to the image list returned
-by CROC Cloud. This allows more advanced filtering not supported from the CROC Cloud API. This
-filtering is done locally on what CROC Cloud returns, and could have a performance
-impact if the result is large. It is recommended to combine this with other
-options to narrow down the list CROC Cloud returns.
+* `name_regex` - (Optional) A regex string to apply to the image list returned by the EC2 API.
+  This allows more advanced filtering. It is done locally on what the EC2 API returns,
+  and could have a performance impact if the result is large.
+  It is recommended to combine this with other options to narrow down the list the EC2 API returns.
 * `sort_ascending`  - (Defaults to `false`) Used to sort images by creation time.
 
 ## Attributes Reference

--- a/website/docs/d/ami_ids.html.markdown
+++ b/website/docs/d/ami_ids.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
-page_title: "AWS: aws_ami_ids"
+page_title: "aws_ami_ids"
 description: |-
   Provides a list of image IDs.
 ---

--- a/website/docs/d/autoscaling_group.html.markdown
+++ b/website/docs/d/autoscaling_group.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Auto Scaling"
 layout: "aws"
-page_title: "AWS: aws_autoscaling_group"
+page_title: "aws_autoscaling_group"
 description: |-
   Get information on an Auto Scaling Group.
 ---

--- a/website/docs/d/autoscaling_group.html.markdown
+++ b/website/docs/d/autoscaling_group.html.markdown
@@ -40,7 +40,7 @@ data "aws_autoscaling_group" "example" {
 * `vpc_zone_identifier` - The IDs of the subnets in which instances are created.
 
 ->  **Unsupported attributes**
-These attributes are currently unsupported by CROC Cloud:
+These attributes are currently unsupported:
 
 * `enabled_metrics` - The list of metrics enabled for collection. Always empty.
 * `health_check_type` - The service to use for the health checks. Always `""`.

--- a/website/docs/d/availability_zone.html.markdown
+++ b/website/docs/d/availability_zone.html.markdown
@@ -56,7 +56,7 @@ In addition to all arguments above, the following attributes are exported:
 * `state` - A specific availability zone state to require. Possible values: `"available"`, `"information"`, `"impaired"`, `"unavailable"`.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `all_availability_zones` - Whether all availability zones and local zones are included regardless of your opt in status. Always empty.
 * `group_name` - Group name. Always `""`.

--- a/website/docs/d/availability_zone.html.markdown
+++ b/website/docs/d/availability_zone.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
-page_title: "AWS: aws_availability_zone"
+page_title: "aws_availability_zone"
 description: |-
     Provides details about a specific availability zone
 ---

--- a/website/docs/d/availability_zones.html.markdown
+++ b/website/docs/d/availability_zones.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
-page_title: "AWS: aws_availability_zones"
+page_title: "aws_availability_zones"
 description: |-
     Provides a list of availability zones which can be used by an AWS account.
 ---

--- a/website/docs/d/availability_zones.html.markdown
+++ b/website/docs/d/availability_zones.html.markdown
@@ -55,7 +55,7 @@ In addition to all arguments above, the following attributes are exported:
 * `names` - A list of the availability zone names available to the account.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `all_availability_zones` - Whether all availability zones and local zones are included regardless of your opt in status. Always empty.
 * `exclude_names` - List of availability zone names to exclude. Always empty.

--- a/website/docs/d/availability_zones.html.markdown
+++ b/website/docs/d/availability_zones.html.markdown
@@ -3,13 +3,12 @@ subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
 page_title: "aws_availability_zones"
 description: |-
-    Provides a list of availability zones which can be used by an AWS account.
+    Provides a list of availability zones.
 ---
 
 # Data Source: aws_availability_zones
 
-The availability zones data source allows access to the list of CROC Cloud
-availability zones which can be accessed by an CROC Cloud account.
+Provides a list of availability zones.
 
 This is different from the [`aws_availability_zone`][tf-availability-zone] (singular) data source,
 which provides some details about a specific availability zone.

--- a/website/docs/d/canonical_user_id.html.markdown
+++ b/website/docs/d/canonical_user_id.html.markdown
@@ -3,14 +3,12 @@ subcategory: "S3 (Simple Storage)"
 layout: "aws"
 page_title: "aws_canonical_user_id"
 description: |-
-  Provides the canonical user ID (CROC Cloud S3 User ID) associated with the provider
-  connection to CROC Cloud.
+  Provides the canonical user ID (S3 User ID) associated with the used account.
 ---
 
 # Data Source: aws_canonical_user_id
 
-The Canonical User ID data source allows access to the CROC Cloud S3 User ID
-for the effective account in which Terraform is working.  
+Provides the canonical user ID (S3 User ID) associated with the used account
 
 ~> **NOTE:** To use this data source, you must have the `s3:ListAllMyBuckets` permission.
 
@@ -32,5 +30,5 @@ There are no arguments available for this data source.
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The canonical user ID (CROC Cloud S3 User ID) associated with the provider connection to CROC Cloud.
+* `id` - The canonical user ID (S3 User ID) associated with the used account.
 * `display_name` - The human-friendly name linked to the canonical user ID. The bucket owner's display name.

--- a/website/docs/d/canonical_user_id.html.markdown
+++ b/website/docs/d/canonical_user_id.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "S3 (Simple Storage)"
 layout: "aws"
-page_title: "CROC Cloud: aws_canonical_user_id"
+page_title: "aws_canonical_user_id"
 description: |-
   Provides the canonical user ID (CROC Cloud S3 User ID) associated with the provider
   connection to CROC Cloud.

--- a/website/docs/d/customer_gateway.html.markdown
+++ b/website/docs/d/customer_gateway.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPN (Site-to-Site)"
 layout: "aws"
-page_title: "AWS: aws_customer_gateway"
+page_title: "aws_customer_gateway"
 description: |-
   Get an existing Customer Gateway.
 ---

--- a/website/docs/d/customer_gateway.html.markdown
+++ b/website/docs/d/customer_gateway.html.markdown
@@ -12,7 +12,7 @@ Get an existing customer gateway.
 
 ## Example Usage
 
--> In CROC Cloud the terms VPC, Internet Gateway, VPN Gateway are equivalent
+-> The terms VPC, Internet Gateway, VPN Gateway are equivalent.
 
 ```terraform
 data "aws_customer_gateway" "selected" {

--- a/website/docs/d/customer_gateway.html.markdown
+++ b/website/docs/d/customer_gateway.html.markdown
@@ -54,7 +54,7 @@ In addition to the arguments above, the following attributes are exported:
 * `type` - The type of customer gateway. Possible values: `ipsec.1`, `ipsec.legacy`.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `certificate_arn` - The ARN for the customer gateway certificate. Always `""`.
 * `device_name` - A name for the customer gateway device. Always `""`.

--- a/website/docs/d/ebs_snapshot.html.markdown
+++ b/website/docs/d/ebs_snapshot.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EBS (EC2)"
 layout: "aws"
-page_title: "AWS: aws_ebs_snapshot"
+page_title: "aws_ebs_snapshot"
 description: |-
   Get information on an EBS snapshot.
 ---

--- a/website/docs/d/ebs_snapshot.html.markdown
+++ b/website/docs/d/ebs_snapshot.html.markdown
@@ -34,9 +34,10 @@ data "aws_ebs_snapshot" "ebs_snapshot" {
 The following arguments are supported:
 
 * `most_recent` - (Optional) If more than one result is returned, use the most recent snapshot.
-* `owners` - (Optional) Returns the snapshots owned by the specified owner ID. Multiple owners can be specified.
+* `owners` - (Optional) List of the snapshot owners. Valid items are the project ID (`project@customer`) or `self`.  
 * `snapshot_ids` - (Optional) Returns information on a specific snapshot ID.
-* `restorable_by_user_ids` - (Optional) One or more CROC Cloud project IDs that can create volumes from the snapshot.
+* `restorable_by_user_ids` - (Optional) List of the project IDs (`project@customer`).
+  that can create volumes from the snapshot.
 * `filter` - (Optional) One or more name/value pairs to filter.
 
 For more information about filtering, see the [EC2 API documentation][describe-snapshots].
@@ -49,7 +50,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The snapshot ID (e.g., snap-12345678).
 * `snapshot_id` - The snapshot ID (e.g., snap-12345678).
 * `description` - A description for the snapshot
-* `owner_id` - The CROC Cloud project ID.
+* `owner_id` - The project ID.
 * `owner_alias` - The alias of the EBS snapshot owner.
 * `volume_id` - The volume ID (e.g., vol-12345678).
 * `volume_size` - The size of the drive in GiB.

--- a/website/docs/d/ebs_snapshot.html.markdown
+++ b/website/docs/d/ebs_snapshot.html.markdown
@@ -57,7 +57,7 @@ In addition to all arguments above, the following attributes are exported:
 * `tags` - A map of tags for the resource.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `data_encryption_key_id` - The data encryption key identifier for the snapshot. Always `""`.
 * `encrypted` - Whether the snapshot is encrypted. Always `false`.

--- a/website/docs/d/ebs_snapshot_ids.html.markdown
+++ b/website/docs/d/ebs_snapshot_ids.html.markdown
@@ -42,5 +42,5 @@ For more information about filtering, see the [EC2 API documentation][describe-s
 
 ## Attributes Reference
 
-* `id` - Region (for example, `croc`).
+* `id` - The region (e.g., `region-1`).
 * `ids` - Set of EBS snapshot IDs, sorted by creation time in descending order.

--- a/website/docs/d/ebs_snapshot_ids.html.markdown
+++ b/website/docs/d/ebs_snapshot_ids.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EBS (EC2)"
 layout: "aws"
-page_title: "CROC Cloud: aws_ebs_snapshot_ids"
+page_title: "aws_ebs_snapshot_ids"
 description: |-
   Provides a list of EBS snapshot IDs.
 ---

--- a/website/docs/d/ebs_snapshot_ids.html.markdown
+++ b/website/docs/d/ebs_snapshot_ids.html.markdown
@@ -34,8 +34,9 @@ data "aws_ebs_snapshot_ids" "ebs_snapshot_ids" {
 
 The following arguments are supported:
 
-* `owners` - (Optional) Returns the snapshots owned by the specified owner ID. Multiple owners can be specified.
-* `restorable_by_user_ids` - (Optional) One or more CROC Cloud project IDs that can create volumes from the snapshot.
+* `owners` - (Optional) List of the snapshot owners. Valid items are the project ID (`project@customer`) or `self`.
+* `restorable_by_user_ids` - (Optional) List of the project IDs (`project@customer`).
+  that can create volumes from the snapshot.
 * `filter` - (Optional) One or more name/value pairs to filter.
 
 For more information about filtering, see the [EC2 API documentation][describe-snapshots].

--- a/website/docs/d/ebs_volume.html.markdown
+++ b/website/docs/d/ebs_volume.html.markdown
@@ -53,7 +53,7 @@ In addition to all arguments above, the following attributes are exported:
 * `throughput` - The throughput that the volume supports, in MiB/s.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `encrypted` - Whether the snapshot is encrypted. Always `false`.
 * `kms_key_id` - The ARN for the KMS encryption key. Always `""`.

--- a/website/docs/d/ebs_volume.html.markdown
+++ b/website/docs/d/ebs_volume.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EBS (EC2)"
 layout: "aws"
-page_title: "AWS: aws_ebs_volume"
+page_title: "aws_ebs_volume"
 description: |-
   Get information on an EBS volume.
 ---

--- a/website/docs/d/ebs_volumes.html.markdown
+++ b/website/docs/d/ebs_volumes.html.markdown
@@ -64,7 +64,7 @@ For more information about filtering, see the [EC2 API documentation][describe-v
 
 ## Attributes Reference
 
-* `id` - Region (for example, `croc`).
+* `id` - The region (e.g., `region-1`).
 * `ids` - A set of all the EBS volume IDs found.
 
 [describe-volumes]: https://docs.cloud.croc.ru/en/api/ec2/volumes/DescribeVolumes.html

--- a/website/docs/d/ebs_volumes.html.markdown
+++ b/website/docs/d/ebs_volumes.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EBS (EC2)"
 layout: "aws"
-page_title: "AWS: aws_ebs_volumes"
+page_title: "aws_ebs_volumes"
 description: |-
     Provides identifying information for EBS volumes matching given criteria
 ---

--- a/website/docs/d/ec2_host.html.markdown
+++ b/website/docs/d/ec2_host.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
-page_title: "AWS: aws_ec2_host"
+page_title: "aws_ec2_host"
 description: |-
   Provides information about a dedicated host.
 ---
@@ -28,7 +28,7 @@ data "aws_ec2_host" "selected" {
     name   = "auto-placement"
     values = ["on"]
   }
-  
+
   filter {
     name   = "state"
     values = ["available"]
@@ -61,6 +61,6 @@ In addition to all arguments above, the following attributes are exported:
 * `host_recovery` - Indicates whether host recovery is enabled or disabled for the dedicated host.
 * `id` - The ID of the dedicated host.
 * `instance_family` - Instance family supported by the dedicated host.
-* `owner_id` - The ID of the account that owns the dedicated host.
+* `owner_id` - The ID of the project that owns the dedicated host.
 * `sockets` - Number of sockets on the dedicated host.
 * `total_vcpus` - Total number of vCPUs on the dedicated host.

--- a/website/docs/d/ec2_transit_gateway.html.markdown
+++ b/website/docs/d/ec2_transit_gateway.html.markdown
@@ -55,9 +55,9 @@ In addition to all arguments above, the following attributes are exported:
 * `default_route_table_association` - Indicates whether the association with default association route table is created automatically.
 * `default_route_table_propagation` - Indicates whether the routes are automatically propagated to the default propagation route table.
 * `description` - The description of the transit gateway
-* `owner_id` - The ID of CROC Cloud account that owns the transit gateway.
+* `owner_id` - The ID of the project that owns the transit gateway.
 * `propagation_default_route_table_id` - The ID of the default propagation route table.
-* `shared_owners` - List of CROC Cloud account IDs that are granted access to the transit gateway.
+* `shared_owners` - List of project IDs that are granted access to the transit gateway.
 * `tags` - Map of tags assigned to the transit gateway.
 
 ->  **Unsupported attributes**

--- a/website/docs/d/ec2_transit_gateway.html.markdown
+++ b/website/docs/d/ec2_transit_gateway.html.markdown
@@ -61,7 +61,7 @@ In addition to all arguments above, the following attributes are exported:
 * `tags` - Map of tags assigned to the transit gateway.
 
 ->  **Unsupported attributes**
-These attributes are currently unsupported by CROC Cloud:
+These attributes are currently unsupported:
 
 * `amazon_side_asn` - Private Autonomous System Number (ASN) for the Amazon side of a BGP session. Always `0`.
 * `arn` - The ARN of the transit gateway. Always `""`.

--- a/website/docs/d/ec2_transit_gateway.html.markdown
+++ b/website/docs/d/ec2_transit_gateway.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Transit Gateway"
 layout: "aws"
-page_title: "CROC Cloud: aws_ec2_transit_gateway"
+page_title: "aws_ec2_transit_gateway"
 description: |-
   Provides information about a transit gateway.
 ---

--- a/website/docs/d/ec2_transit_gateway_route_table.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_route_table.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Transit Gateway"
 layout: "aws"
-page_title: "CROC Cloud: aws_ec2_transit_gateway_route_table"
+page_title: "aws_ec2_transit_gateway_route_table"
 description: |-
   Provides information about a transit gateway route table.
 ---

--- a/website/docs/d/ec2_transit_gateway_route_tables.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_route_tables.html.markdown
@@ -43,6 +43,6 @@ In addition to all arguments above, the following attributes are exported:
 * `ids` - List of transit gateway route table IDs.
 
 ->  **Unsupported attributes**
-These attributes are currently unsupported by CROC Cloud:
+These attributes are currently unsupported:
 
 * `tags` - A mapping of tags, each pair of which must exactly match a pair on the desired transit gateway route table. Always empty.

--- a/website/docs/d/ec2_transit_gateway_route_tables.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_route_tables.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The region (e.g., `croc`).
+* `id` - The region (e.g., `region-1`).
 * `ids` - List of transit gateway route table IDs.
 
 ->  **Unsupported attributes**

--- a/website/docs/d/ec2_transit_gateway_route_tables.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_route_tables.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Transit Gateway"
 layout: "aws"
-page_title: "CROC Cloud: aws_ec2_transit_gateway_route_tables"
+page_title: "aws_ec2_transit_gateway_route_tables"
 description: |-
   Provides list of transit gateway route table IDs.
 ---

--- a/website/docs/d/ec2_transit_gateway_vpc_attachment.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_vpc_attachment.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Transit Gateway"
 layout: "aws"
-page_title: "CROC Cloud: aws_ec2_transit_gateway_vpc_attachment"
+page_title: "aws_ec2_transit_gateway_vpc_attachment"
 description: |-
   Provides information about a transit gateway VPC attachment.
 ---

--- a/website/docs/d/ec2_transit_gateway_vpc_attachment.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_vpc_attachment.html.markdown
@@ -59,7 +59,7 @@ In addition to all arguments above, the following attributes are exported:
 * `vpc_owner_id` - The ID of CROC Cloud account that owns the VPC.
 
 ->  **Unsupported attributes**
-These attributes are currently unsupported by CROC Cloud:
+These attributes are currently unsupported:
 
 * `appliance_mode_support` - Whether Appliance Mode support is enabled. Always empty.
 * `dns_support` - Whether DNS support is enabled. Always empty.

--- a/website/docs/d/ec2_transit_gateway_vpc_attachment.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_vpc_attachment.html.markdown
@@ -56,7 +56,7 @@ In addition to all arguments above, the following attributes are exported:
 * `transit_gateway_id` - The ID of the transit gateway.
 * `tags` - Map of tags assigned to the transit gateway VPC attachment.
 * `vpc_id` - The ID of the VPC.
-* `vpc_owner_id` - The ID of CROC Cloud account that owns the VPC.
+* `vpc_owner_id` - The ID of the project that owns the VPC.
 
 ->  **Unsupported attributes**
 These attributes are currently unsupported:

--- a/website/docs/d/ec2_transit_gateway_vpc_attachments.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_vpc_attachments.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Transit Gateway"
 layout: "aws"
-page_title: "CROC Cloud: aws_ec2_transit_gateway_vpc_attachments"
+page_title: "aws_ec2_transit_gateway_vpc_attachments"
 description: |-
   Provides list of transit gateway VPC attachment IDs.
 ---

--- a/website/docs/d/eip.html.markdown
+++ b/website/docs/d/eip.html.markdown
@@ -79,7 +79,7 @@ In addition to all arguments above, the following attributes are exported:
 * `tags` - Key-value map of tags associated with Elastic IP.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `carrier_ip` - Carrier IP address. Always `""`.
 * `customer_owned_ip` - Customer owned IP. Always `""`.

--- a/website/docs/d/eip.html.markdown
+++ b/website/docs/d/eip.html.markdown
@@ -72,7 +72,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - If VPC Elastic IP, the allocation identifier.
 * `instance_id` - The ID of the instance that the address is associated with (if any).
 * `network_interface_id` - The ID of the network interface.
-* `network_interface_owner_id` - The ID of the CROC Cloud project that owns the network interface.
+* `network_interface_owner_id` - The ID of the project that owns the network interface.
 * `private_ip` - The private IP address associated with the Elastic IP address.
 * `public_ip` - Public IP address of Elastic IP.
 * `public_ipv4_pool` - The ID of an address pool.

--- a/website/docs/d/eip.html.markdown
+++ b/website/docs/d/eip.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
-page_title: "AWS: aws_eip"
+page_title: "aws_eip"
 description: |-
     Provides details about a specific Elastic IP
 ---

--- a/website/docs/d/eips.html.markdown
+++ b/website/docs/d/eips.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
-page_title: "AWS: aws_eips"
+page_title: "aws_eips"
 description: |-
     Provides a list of Elastic IPs in a region
 ---

--- a/website/docs/d/eips.html.markdown
+++ b/website/docs/d/eips.html.markdown
@@ -47,6 +47,6 @@ For more information about filtering, see the [EC2 API documentation][describe-a
 
 ## Attributes Reference
 
-* `id` - Region (for example, `croc`).
+* `id` - The region (e.g., `region-1`).
 * `allocation_ids` - A list of all the allocation IDs.
 * `public_ips` - A list of all the Elastic IP addresses.

--- a/website/docs/d/eks_cluster.html.markdown
+++ b/website/docs/d/eks_cluster.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EKS (Elastic Kubernetes)"
 layout: "aws"
-page_title: "CROC Cloud: aws_eks_cluster"
+page_title: "aws_eks_cluster"
 description: |-
   Retrieves information about an EKS cluster.
 ---

--- a/website/docs/d/eks_cluster.html.markdown
+++ b/website/docs/d/eks_cluster.html.markdown
@@ -43,7 +43,7 @@ data "aws_eks_cluster" "example" {
 * `tags` - Key-value map of resource tags.
 
 ->  **Unsupported attributes**
-These attributes are currently unsupported by CROC Cloud:
+These attributes are currently unsupported:
 
 * `enabled_cluster_log_types` - The enabled control plane logs. Always empty.
 * `encryption_config` - Configuration block with encryption configuration for the cluster. Always empty.

--- a/website/docs/d/eks_cluster.html.markdown
+++ b/website/docs/d/eks_cluster.html.markdown
@@ -36,7 +36,7 @@ data "aws_eks_cluster" "example" {
 * `status` - The status of the EKS cluster. One of `CLAIMED`, `CREATING`, `DELETED`, `DELETING`, `ERROR`, `MODIFYING`, `PENDING`, `PROVISIONING`, `READY`, `REPAIRING`.
 * `version` - The Kubernetes server version for the cluster.
 * `vpc_config` - Nested list containing VPC configuration for the cluster.
-    * `cluster_security_group_id` - The cluster security group that was created by CROC Cloud EKS for the cluster.
+    * `cluster_security_group_id` - The cluster security group that was created by the cloud for the cluster.
     * `security_group_ids` – List of security group IDs.
     * `subnet_ids` – List of subnet IDs.
     * `vpc_id` – The VPC associated with your cluster.

--- a/website/docs/d/eks_cluster_auth.html.markdown
+++ b/website/docs/d/eks_cluster_auth.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EKS (Elastic Kubernetes)"
 layout: "aws"
-page_title: "AWS: aws_eks_cluster_auth"
+page_title: "aws_eks_cluster_auth"
 description: |-
   Get an authentication token to communicate with an EKS Cluster
 ---

--- a/website/docs/d/eks_clusters.html.markdown
+++ b/website/docs/d/eks_clusters.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EKS (Elastic Kubernetes)"
 layout: "aws"
-page_title: "CROC Cloud: aws_eks_clusters"
+page_title: "aws_eks_clusters"
 description: |-
   Retrieves the EKS clusters names.
 ---

--- a/website/docs/d/eks_node_group.html.markdown
+++ b/website/docs/d/eks_node_group.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EKS (Elastic Kubernetes)"
 layout: "aws"
-page_title: "CROC Cloud: aws_eks_node_group"
+page_title: "aws_eks_node_group"
 description: |-
   Retrieves information about an EKS node group.
 ---

--- a/website/docs/d/eks_node_group.html.markdown
+++ b/website/docs/d/eks_node_group.html.markdown
@@ -50,7 +50,7 @@ data "aws_eks_node_group" "example" {
 * `version` – Kubernetes version.
 
 ->  **Unsupported attributes**
-These attributes are currently unsupported by CROC Cloud:
+These attributes are currently unsupported:
 
 * `ami_type` - Type of image associated with the EKS node group. Always `""`.
 * `node_role_arn` – The ARN of the IAM Role that provides permissions for the EKS node group. Always `""`.

--- a/website/docs/d/eks_node_groups.html.markdown
+++ b/website/docs/d/eks_node_groups.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EKS (Elastic Kubernetes)"
 layout: "aws"
-page_title: "CROC Cloud: aws_eks_node_groups"
+page_title: "aws_eks_node_groups"
 description: |-
   Retrieves the EKS node groups names associated with a named EKS cluster.
 ---

--- a/website/docs/d/instance.html.markdown
+++ b/website/docs/d/instance.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
-page_title: "CROC Cloud: aws_instance"
+page_title: "aws_instance"
 description: |-
   Provides information about an EC2 instance.
 ---

--- a/website/docs/d/instance.html.markdown
+++ b/website/docs/d/instance.html.markdown
@@ -104,7 +104,7 @@ interpolation.
 * `vpc_security_group_ids` - The associated security groups in a non-default VPC.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `credit_specification` - Configuration block for customizing the credit specification of the instance. Always empty.
 * `ebs_block_device`:

--- a/website/docs/d/instances.html.markdown
+++ b/website/docs/d/instances.html.markdown
@@ -55,7 +55,7 @@ For more information about filtering, see the [EC2 API documentation][describe-i
 
 ## Attributes Reference
 
-* `id` - Region (for example, `croc`).
+* `id` - The region (e.g., `region-1`).
 * `ids` - IDs of instances found through the filter.
 * `private_ips` - Private IP addresses of instances found through the filter.
 * `public_ips` - Public IP addresses of instances found through the filter.

--- a/website/docs/d/instances.html.markdown
+++ b/website/docs/d/instances.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
-page_title: "CROC Cloud: aws_instances"
+page_title: "aws_instances"
 description: |-
   Provides information about an EC2 instances.
 ---

--- a/website/docs/d/key_pair.html.markdown
+++ b/website/docs/d/key_pair.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
-page_title: "AWS: aws_key_pair"
+page_title: "aws_key_pair"
 description: |-
     Provides details about a specific EC2 Key Pair.
 ---

--- a/website/docs/d/launch_template.html.markdown
+++ b/website/docs/d/launch_template.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
-page_title: "CROC Cloud: aws_launch_template"
+page_title: "aws_launch_template"
 description: |-
   Provides an EC2 launch template data source.
 ---

--- a/website/docs/d/lb.html.markdown
+++ b/website/docs/d/lb.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "ELB (Elastic Load Balancing)"
 layout: "aws"
-page_title: "AWS: aws_lb"
+page_title: "aws_lb"
 description: |-
   Provides a Load Balancer data source.
 ---

--- a/website/docs/d/lb_listener.html.markdown
+++ b/website/docs/d/lb_listener.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "ELB (Elastic Load Balancing)"
 layout: "aws"
-page_title: "AWS: aws_lb_listener"
+page_title: "aws_lb_listener"
 description: |-
   Provides a Load Balancer Listener data source.
 ---

--- a/website/docs/d/lb_target_group.html.markdown
+++ b/website/docs/d/lb_target_group.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "ELB (Elastic Load Balancing)"
 layout: "aws"
-page_title: "AWS: aws_lb_target_group"
+page_title: "aws_lb_target_group"
 description: |-
   Provides a Load Balancer Target Group data source.
 ---

--- a/website/docs/d/network_acls.html.markdown
+++ b/website/docs/d/network_acls.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_network_acls"
+page_title: "aws_network_acls"
 description: |-
     Provides a list of network ACL ids for a VPC
 ---

--- a/website/docs/d/network_acls.html.markdown
+++ b/website/docs/d/network_acls.html.markdown
@@ -74,7 +74,7 @@ For more information about filtering, see the [EC2 API documentation][describe-n
 
 ## Attributes Reference
 
-* `id` - Region (for example, `croc`).
+* `id` - The region (e.g., `region-1`).
 * `ids` - A list of all the network ACL ids found.
 
 [describe-network-acls]: https://docs.cloud.croc.ru/en/api/ec2/network_acls/DescribeNetworkAcls.html

--- a/website/docs/d/network_interface.html.markdown
+++ b/website/docs/d/network_interface.html.markdown
@@ -48,7 +48,7 @@ Additionally, the following attributes are exported:
 * `vpc_id` - The ID of the VPC.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `interface_type` - The type of interface. Always `"interface"`.
 * `ipv6_addresses` - List of IPv6 addresses to assign to the ENI. Always empty.
@@ -65,7 +65,7 @@ These exported attributes are currently unsupported by CROC Cloud:
 * `public_ip` - The address of the elastic IP address bound to the network interface.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `carrier_ip` - The carrier IP address associated with the network interface. This attribute is only set when the network interface is in a subnet which is associated with a Wavelength Zone.
 

--- a/website/docs/d/network_interface.html.markdown
+++ b/website/docs/d/network_interface.html.markdown
@@ -38,7 +38,7 @@ Additionally, the following attributes are exported:
 * `availability_zone` - The availability zone.
 * `description` - Description of the network interface.
 * `mac_address` - The MAC address.
-* `owner_id` - The CROC Cloud project ID.
+* `owner_id` - The project ID.
 * `private_dns_name` - The private DNS name.
 * `private_ip` - The private IPv4 address of the network interface within the subnet.
 * `private_ips` - The private IPv4 addresses associated with the network interface.

--- a/website/docs/d/network_interface.html.markdown
+++ b/website/docs/d/network_interface.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_network_interface"
+page_title: "aws_network_interface"
 description: |-
   Get information on a Network Interface resource.
 ---

--- a/website/docs/d/network_interfaces.html.markdown
+++ b/website/docs/d/network_interfaces.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_network_interfaces"
+page_title: "aws_network_interfaces"
 description: |-
     Provides a list of network interface ids
 ---

--- a/website/docs/d/network_interfaces.html.markdown
+++ b/website/docs/d/network_interfaces.html.markdown
@@ -65,7 +65,7 @@ For more information about filtering, see the [EC2 API documentation][describe-n
 
 ## Attributes Reference
 
-* `id` - Region (for example, `croc`).
+* `id` - The region (e.g., `region-1`).
 * `ids` - A list of all the network interface IDs found.
 
 [describe-network-interfaces]: https://docs.cloud.croc.ru/en/api/ec2/network_interfaces/DescribeNetworkInterfaces.html

--- a/website/docs/d/paas_backup.html.markdown
+++ b/website/docs/d/paas_backup.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `databases` - List of databases. The structure of this block is [described below](#databases).
-* `id` - The region (e.g., `croc`) if `id` is not specified as an argument.
+* `id` - The region (e.g., `region-1`) if `id` is not specified as an argument.
 * `protected` - Indicates whether the backup is protected from automatic scheduled deletion.
 * `service_deleted` - Indicates whether the service is deleted.
 * `service_name` - The service name.

--- a/website/docs/d/paas_backup.html.markdown
+++ b/website/docs/d/paas_backup.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "PaaS"
 layout: "aws"
-page_title: "CROC Cloud: aws_paas_backup"
+page_title: "aws_paas_backup"
 description: |-
   Provides information about a PaaS service backup.
 ---

--- a/website/docs/d/paas_backup_users.html.markdown
+++ b/website/docs/d/paas_backup_users.html.markdown
@@ -32,7 +32,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The region (e.g., `croc`).
+* `id` - The region (e.g., `region-1`).
 * `users` - List of users. Each user has the following structure:
     * `email` - The user email.
     * `enabled` - Indicates whether the user is active.

--- a/website/docs/d/paas_backup_users.html.markdown
+++ b/website/docs/d/paas_backup_users.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "PaaS"
 layout: "aws"
-page_title: "CROC Cloud: aws_paas_backup_users"
+page_title: "aws_paas_backup_users"
 description: |-
   Provides information about users with the PaaS Backup User project privileges.
 ---

--- a/website/docs/d/paas_backups.html.markdown
+++ b/website/docs/d/paas_backups.html.markdown
@@ -38,4 +38,4 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `backup_ids` - List of backup IDs.
-* `id` - The region (e.g., `croc`).
+* `id` - The region (e.g., `region-1`).

--- a/website/docs/d/paas_backups.html.markdown
+++ b/website/docs/d/paas_backups.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "PaaS"
 layout: "aws"
-page_title: "CROC Cloud: aws_paas_backups"
+page_title: "aws_paas_backups"
 description: |-
   Provides list of PaaS service backups IDs.
 ---

--- a/website/docs/d/paas_service.html.markdown
+++ b/website/docs/d/paas_service.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "PaaS"
 layout: "aws"
-page_title: "CROC Cloud: aws_paas_service"
+page_title: "aws_paas_service"
 description: |-
   Provides information about a PaaS service.
 ---

--- a/website/docs/d/paas_service.html.markdown
+++ b/website/docs/d/paas_service.html.markdown
@@ -32,7 +32,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `auto_created_security_group_ids` - List of security group IDs that CROC Cloud created for the service.
+* `auto_created_security_group_ids` - List of security group IDs that cloud created for the service.
 * `backup_settings` - The backup settings for the service. The structure of this block is [described below](#backup_settings).
 * `data_volume` - The data volume parameters for the service. The structure of this block is [described below](#data_volume).
 * `endpoints` - List of endpoints for connecting to the service.

--- a/website/docs/d/route.html.markdown
+++ b/website/docs/d/route.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_route"
+page_title: "aws_route"
 description: |-
     Provides details about a specific Route
 ---

--- a/website/docs/d/route.html.markdown
+++ b/website/docs/d/route.html.markdown
@@ -50,7 +50,7 @@ The following arguments are optional:
 * `transit_gateway_id` - (Optional) The ID of the transit gateway.
 
 ->  **Unsupported arguments**
-These arguments are currently unsupported by CROC Cloud:
+These arguments are currently unsupported:
 
 * `carrier_gateway_id` - ID of a carrier gateway. Always `""`.
 * `core_network_arn` - ARN of a core network. Always `""`.

--- a/website/docs/d/route53_zone.html.markdown
+++ b/website/docs/d/route53_zone.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Route 53"
 layout: "aws"
-page_title: "CROC Cloud: aws_route53_zone"
+page_title: "aws_route53_zone"
 description: |-
     Provides details about a specific Route 53 Hosted Zone
 ---

--- a/website/docs/d/route53_zone.html.markdown
+++ b/website/docs/d/route53_zone.html.markdown
@@ -61,7 +61,7 @@ The following attribute is additionally exported:
 * `resource_record_set_count` - The number of Record Set in the Hosted Zone.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `linked_service_principal` - The service that created the Hosted Zone (e.g., `servicediscovery.amazonaws.com`). Always `""`.
 * `linked_service_description` - The description provided by the service that created the Hosted Zone (e.g., `arn:aws:servicediscovery:us-east-1:1234567890:namespace/ns-xxxxxxxxxxxxxxxx`). Always `""`.

--- a/website/docs/d/route_table.html.markdown
+++ b/website/docs/d/route_table.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_route_table"
+page_title: "aws_route_table"
 description: |-
     Provides details about a specific Route Table
 ---

--- a/website/docs/d/route_table.html.markdown
+++ b/website/docs/d/route_table.html.markdown
@@ -64,7 +64,7 @@ In addition to the arguments above, the following attributes are exported:
 ->  **Unsupported attributes**
 These attributes are currently unsupported:
 
-* `owner_id` - ID of the CROC Cloud account that owns the route table. Always `""`.
+* `owner_id` - The ID of the project that owns the route table. Always `""`.
 
 ### routes
 

--- a/website/docs/d/route_table.html.markdown
+++ b/website/docs/d/route_table.html.markdown
@@ -62,7 +62,7 @@ In addition to the arguments above, the following attributes are exported:
 * `routes` - List of routes with attributes detailed below.
 
 ->  **Unsupported attributes**
-These attributes are currently unsupported by CROC Cloud:
+These attributes are currently unsupported:
 
 * `owner_id` - ID of the CROC Cloud account that owns the route table. Always `""`.
 
@@ -75,7 +75,7 @@ For destinations:
 * `cidr_block` - CIDR block of the route.
 
 ->  **Unsupported attributes**
-These attributes are currently unsupported by CROC Cloud:
+These attributes are currently unsupported:
 
 * `destination_prefix_list_id` - ID of a managed prefix list destination of the route. Always `""`.
 * `ipv6_cidr_block` - The IPv6 CIDR block of the route. Always `""`.
@@ -88,7 +88,7 @@ For targets:
 * `transit_gateway_id` - The ID of the transit gateway.
 
 ->  **Unsupported attributes**
-These attributes are currently unsupported by CROC Cloud:
+These attributes are currently unsupported:
 
 * `carrier_gateway_id` - ID of the Carrier Gateway. Always `""`.
 * `core_network_arn` - ARN of the core network. Always `""`.

--- a/website/docs/d/route_tables.html.markdown
+++ b/website/docs/d/route_tables.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_route_tables"
+page_title: "aws_route_tables"
 description: |-
     Get information on route tables.
 ---

--- a/website/docs/d/route_tables.html.markdown
+++ b/website/docs/d/route_tables.html.markdown
@@ -43,7 +43,7 @@ For more information about filtering, see the [EC2 API documentation][describe-r
 
 ## Attributes Reference
 
-* `id` - Region (for example, `croc`).
+* `id` - The region (e.g., `region-1`).
 * `ids` - A list of all the route table ids found.
 
 [describe-route-tables]: https://docs.cloud.croc.ru/en/api/ec2/routes/DescribeRouteTables.html

--- a/website/docs/d/s3_bucket.html.markdown
+++ b/website/docs/d/s3_bucket.html.markdown
@@ -37,7 +37,7 @@ In addition to all arguments above, the following attributes are exported:
 * `region` - The region this bucket resides in.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `bucket_domain_name` - The bucket domain name. Contains domain name of format `bucketname.s3.amazonaws.com`.
 * `bucket_regional_domain_name` - The bucket region-specific domain name. Contains domain name based on AWS region.

--- a/website/docs/d/s3_bucket.html.markdown
+++ b/website/docs/d/s3_bucket.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "S3 (Simple Storage)"
 layout: "aws"
-page_title: "CROC Cloud: aws_s3_bucket"
+page_title: "aws_s3_bucket"
 description: |-
     Provides details about a specific S3 bucket.
 ---

--- a/website/docs/d/s3_bucket_object.html.markdown
+++ b/website/docs/d/s3_bucket_object.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "S3 (Simple Storage)"
 layout: "aws"
-page_title: "CROC Cloud: aws_s3_bucket_object"
+page_title: "aws_s3_bucket_object"
 description: |-
     Provides metadata and optionally content of an S3 object
 ---

--- a/website/docs/d/s3_bucket_object.html.markdown
+++ b/website/docs/d/s3_bucket_object.html.markdown
@@ -58,7 +58,7 @@ In addition to all arguments above, the following attributes are exported:
 -> **Note:** Terraform ignores all leading `/`s in the object's `key` and treats multiple `/`s in the rest of the object's `key` as a single `/`, so values of `/index.html` and `index.html` correspond to the same S3 object as do `first//second///third//` and `first/second/third/`.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `bucket_key_enabled` - Whether to use [Amazon S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html) for SSE-KMS. Always `false`.
 * `expires` - The date and time at which the object is no longer cacheable. Always `""`.

--- a/website/docs/d/s3_bucket_objects.html.markdown
+++ b/website/docs/d/s3_bucket_objects.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "S3 (Simple Storage)"
 layout: "aws"
-page_title: "CROC Cloud: aws_s3_bucket_objects"
+page_title: "aws_s3_bucket_objects"
 description: |-
     Returns keys and metadata of S3 objects
 ---

--- a/website/docs/d/s3_bucket_policy.html.markdown
+++ b/website/docs/d/s3_bucket_policy.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "S3 (Simple Storage)"
 layout: "aws"
-page_title: "CROC Cloud: aws_s3_bucket_policy"
+page_title: "aws_s3_bucket_policy"
 description: |-
     Provides a policy of an S3 bucket
 ---

--- a/website/docs/d/s3_object.html.markdown
+++ b/website/docs/d/s3_object.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "S3 (Simple Storage)"
 layout: "aws"
-page_title: "CROC Cloud: aws_s3_object"
+page_title: "aws_s3_object"
 description: |-
     Provides metadata and optionally content of an S3 object
 ---

--- a/website/docs/d/s3_object.html.markdown
+++ b/website/docs/d/s3_object.html.markdown
@@ -56,7 +56,7 @@ In addition to all arguments above, the following attributes are exported:
 -> **Note:** Terraform ignores all leading `/`s in the object's `key` and treats multiple `/`s in the rest of the object's `key` as a single `/`, so values of `/index.html` and `index.html` correspond to the same S3 object as do `first//second///third//` and `first/second/third/`.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `bucket_key_enabled` - Whether to use [Amazon S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html) for SSE-KMS. Always `false`.
 * `expires` - The date and time at which the object is no longer cacheable. Always `""`.

--- a/website/docs/d/s3_objects.html.markdown
+++ b/website/docs/d/s3_objects.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "S3 (Simple Storage)"
 layout: "aws"
-page_title: "CROC Cloud: aws_s3_objects"
+page_title: "aws_s3_objects"
 description: |-
     Returns keys and metadata of S3 objects
 ---

--- a/website/docs/d/security_group.html.markdown
+++ b/website/docs/d/security_group.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_security_group"
+page_title: "aws_security_group"
 description: |-
     Provides details about a specific Security Group
 ---

--- a/website/docs/d/security_groups.html.markdown
+++ b/website/docs/d/security_groups.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_security_groups"
+page_title: "aws_security_groups"
 description: |-
   Get information about a set of Security Groups.
 ---

--- a/website/docs/d/security_groups.html.markdown
+++ b/website/docs/d/security_groups.html.markdown
@@ -47,7 +47,7 @@ For more information about filtering, see the [EC2 API documentation][describe-s
 ## Attributes Reference
 
 * `arns` - ARNs of the matched security groups.
-* `id` - Region (for example, `croc`).
+* `id` - The region (e.g., `region-1`).
 * `ids` - IDs of the matches security groups.
 * `vpc_ids` - The VPC IDs of the matched security groups. The data source's tag or filter *will span VPCs* unless the `vpc-id` filter is also used.
 

--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_subnet"
+page_title: "aws_subnet"
 description: |-
     Provides details about a specific VPC subnet
 ---

--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -90,7 +90,7 @@ In addition to the attributes above, the following attributes are exported but u
 * `map_customer_owned_ip_on_launch` - Whether customer owned IP addresses are assigned on network interface creation. Always `false`.
 * `map_public_ip_on_launch` - Whether public IP addresses are assigned on instance launch. Always `false`.
 * `outpost_arn` - ARN of the Outpost. Always `""`.
-* `owner_id` - ID of the CROC Cloud account that owns the subnet. Always `""`.
+* `owner_id` - The ID of the project that owns the subnet. Always `""`.
 * `private_dns_hostname_type_on_launch` - The type of hostnames assigned to instances in the subnet at launch. Always `""`.
 
 [describe-subnets]: https://docs.cloud.croc.ru/en/api/ec2/subnets/DescribeSubnets.html

--- a/website/docs/d/subnet_ids.html.markdown
+++ b/website/docs/d/subnet_ids.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_subnet_ids"
+page_title: "aws_subnet_ids"
 description: |-
     Provides a set of subnet IDs for a VPC
 ---

--- a/website/docs/d/subnets.html.markdown
+++ b/website/docs/d/subnets.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_subnets"
+page_title: "aws_subnets"
 description: |-
     Get information about a set of subnets.
 ---

--- a/website/docs/d/vpc.html.markdown
+++ b/website/docs/d/vpc.html.markdown
@@ -72,7 +72,7 @@ The following attribute is additionally exported:
 * `main_route_table_id` - ID of the main route table associated with this VPC.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `enable_dns_hostnames` - Whether the VPC has DNS hostname support. Always `true`.
 * `instance_tenancy` - The allowed tenancy of instances launched into the selected VPC. Always `default`.

--- a/website/docs/d/vpc.html.markdown
+++ b/website/docs/d/vpc.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_vpc"
+page_title: "aws_vpc"
 description: |-
     Provides details about a specific VPC
 ---

--- a/website/docs/d/vpc.html.markdown
+++ b/website/docs/d/vpc.html.markdown
@@ -78,7 +78,7 @@ These exported attributes are currently unsupported:
 * `instance_tenancy` - The allowed tenancy of instances launched into the selected VPC. Always `default`.
 * `ipv6_association_id` - The association ID for the IPv6 CIDR block. Always `""`.
 * `ipv6_cidr_block` - The IPv6 CIDR block. Always `""`.
-* `owner_id` - ID of the CROC Cloud account that owns the VPC. Always `""`.
+* `owner_id` - The ID of the project that owns the VPC. Always `""`.
 
 `cidr_block_associations` is also exported with the following attributes:
 

--- a/website/docs/d/vpc_dhcp_options.html.markdown
+++ b/website/docs/d/vpc_dhcp_options.html.markdown
@@ -63,7 +63,7 @@ For more information about filtering, see the [EC2 API documentation][describe-d
 * `tags` - A map of tags assigned to the resource.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `owner_id` - The ID of the CROC Cloud account that owns the DHCP options set.
 

--- a/website/docs/d/vpc_dhcp_options.html.markdown
+++ b/website/docs/d/vpc_dhcp_options.html.markdown
@@ -65,6 +65,6 @@ For more information about filtering, see the [EC2 API documentation][describe-d
 ->  **Unsupported attributes**
 These exported attributes are currently unsupported:
 
-* `owner_id` - The ID of the CROC Cloud account that owns the DHCP options set.
+* `owner_id` -The ID of the project that owns the DHCP options. Always `""`.
 
 [describe-dhcp-options]: https://docs.cloud.croc.ru/en/api/ec2/dhcp_options/DescribeDhcpOptions.html

--- a/website/docs/d/vpc_dhcp_options.html.markdown
+++ b/website/docs/d/vpc_dhcp_options.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_vpc_dhcp_options"
+page_title: "aws_vpc_dhcp_options"
 description: |-
   Retrieve information about an EC2 DHCP Options configuration
 ---

--- a/website/docs/d/vpcs.html.markdown
+++ b/website/docs/d/vpcs.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_vpcs"
+page_title: "aws_vpcs"
 description: |-
     Provides a list of VPC Ids in a region
 ---

--- a/website/docs/d/vpcs.html.markdown
+++ b/website/docs/d/vpcs.html.markdown
@@ -45,7 +45,7 @@ For more information about filtering, see the [EC2 API documentation][describe-v
 
 ## Attributes Reference
 
-* `id` - Region (for example, `croc`).
+* `id` - The region (e.g., `region-1`).
 * `ids` - A list of all the VPC IDs found.
 
 [describe-vpcs]: https://docs.cloud.croc.ru/en/api/ec2/vpcs/DescribeVpcs.html

--- a/website/docs/d/vpn_gateway.html.markdown
+++ b/website/docs/d/vpn_gateway.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPN (Site-to-Site)"
 layout: "aws"
-page_title: "AWS: aws_vpn_gateway"
+page_title: "aws_vpn_gateway"
 description: |-
     Provides details about a specific VPN gateway.
 ---

--- a/website/docs/d/vpn_gateway.html.markdown
+++ b/website/docs/d/vpn_gateway.html.markdown
@@ -11,7 +11,7 @@ description: |-
 The VPN Gateway data source provides details about
 a specific VPN gateway.
 
--> In CROC Cloud the terms VPC, Internet Gateway, VPN Gateway are equivalent
+-> The terms VPC, Internet Gateway, VPN Gateway are equivalent
 
 ## Example Usage
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -1,8 +1,8 @@
 ---
 layout: "aws"
-page_title: "Provider: CROC Cloud"
+page_title: "Provider: Rockit Cloud"
 description: |-
-  Use the Terraform CROC Cloud Provider to interact with the various resources supported by CROC Cloud. You must configure the provider with the proper credentials before you can use it.
+  Use the Terraform Rockit Cloud Provider to interact with the various resources supported by Rockit Cloud. You must configure the provider with the proper credentials before you can use it.
 ---
 
 [hashicorp-tutorials]: https://learn.hashicorp.com/tutorials/terraform/infrastructure-as-code?in=terraform/aws-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS
@@ -11,24 +11,24 @@ description: |-
 [aws-configure-files]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html
 [terraform]: https://docs.cloud.croc.ru/en/api/tools/terraform.html
 
-# CROC Cloud Provider
+# Rockit Cloud Provider
 
-The CROC Cloud Provider is based on the AWS Provider.
-Use it to interact with CROC Cloud services.
+The Rockit Cloud Provider is based on the AWS Provider.
+Use it to interact with Rockit Cloud services.
 The provider needs to be configured with the proper credentials before you can use it.
 
 Use the navigation to the left to read about the available resources.
 
 ~> **NOTE**
-Resource names in the navigation bar have an automatically generated prefix that matches the *croccloud* name.
+Resource names in the navigation bar have an automatically generated prefix that matches the *rockitcloud* name.
 For compatibility with AWS provider configurations, we retained the ``aws`` prefix in resource description and usage examples.
 
 To learn the basics of Terraform using this provider, follow the
 hands-on [get started tutorials][hashicorp-tutorials] on HashiCorp's Learn platform.
 
-Examples of using CROC Cloud services with Terraform can be found in [reference test suite on GitHub][c2-tutorials].
+Examples of using Rockit Cloud services with Terraform can be found in [reference test suite on GitHub][c2-tutorials].
 
-CROC Cloud API is based on AWS API so you can also see examples of using AWS services with Terraform: [AWS services tutorials][aws-tutorials].
+Rockit Cloud API is based on AWS API so you can also see examples of using AWS services with Terraform: [AWS services tutorials][aws-tutorials].
 
 ## Example Usage
 
@@ -38,19 +38,19 @@ For Terraform 0.13 and later:
 terraform {
   required_providers {
     aws = {
-      source  = "c2devel/croccloud"
-      version = "4.14.0-CROC1"
+      source  = "c2devel/rockitcloud"
+      version = "24.1.0"
     }
   }
 }
 
-# Configure the croccloud provider.
+# Configure the rockitcloud provider.
 # The section is named `aws` for backward compatibility.
 provider "aws" {
-  region = "croc"
+  region = "region-1"
 }
 
-# Create a VPC
+# Create a VPC.
 resource "aws_vpc" "example" {
   cidr_block = "10.0.0.0/16"
 }
@@ -58,7 +58,7 @@ resource "aws_vpc" "example" {
 
 ## Authentication and Configuration
 
-Configuration for the CROC Cloud Provider can be derived from several sources,
+Configuration for the Rockit Cloud Provider can be derived from several sources,
 which are applied in the following order:
 
 1. Parameters in the provider configuration.
@@ -77,7 +77,7 @@ Usage:
 
 ```terraform
 provider "aws" {
-  region     = "croc"
+  region     = "region-1"
   access_key = "my-access-key"
   secret_key = "my-secret-key"
 }
@@ -97,13 +97,13 @@ provider "aws" {}
 ```sh
 $ export AWS_ACCESS_KEY_ID="my-access-key"
 $ export AWS_SECRET_ACCESS_KEY="my-secret-key"
-$ export AWS_REGION="croc"
+$ export AWS_REGION="region-1"
 $ terraform plan
 ```
 
 ### Shared Configuration and Credentials Files
 
-CROC Cloud Provider can use [AWS shared configuration and credentials files][aws-configure-files] and source credentials and other settings from them.
+Rockit Cloud Provider can use [AWS shared configuration and credentials files][aws-configure-files] and source credentials and other settings from them.
 By default, these files are located at `$HOME/.aws/config` and `$HOME/.aws/credentials` on Linux and macOS,
 and `"%USERPROFILE%\.aws\config"` and `"%USERPROFILE%\.aws\credentials"` on Windows.
 
@@ -124,6 +124,6 @@ provider "aws" {
 }
 ```
 
-## CROC Cloud Provider Full Configuration
+## Rocki Cloud Provider Full Configuration
 
-For more information about the CROC Cloud Provider configuration, see the documentation on [using Terraform in CROC Cloud][terraform].
+For more information about the Rockit Cloud Provider configuration, see the documentation on [using Terraform][terraform].

--- a/website/docs/r/ami.html.markdown
+++ b/website/docs/r/ami.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
-page_title: "CROC Cloud: aws_ami"
+page_title: "aws_ami"
 description: |-
   Creates and manages a custom Amazon Machine Image (AMI).
 ---

--- a/website/docs/r/ami.html.markdown
+++ b/website/docs/r/ami.html.markdown
@@ -13,7 +13,7 @@ description: |-
 
 The AMI (Amazon Machine Image) resource allows the creation and management of images.
 
-If you just want to share an existing image with another CROC Cloud account,
+If you just want to share an existing image with another project,
 it's better to use [`aws_ami_launch_permission`](ami_launch_permission.html.markdown) instead.
 
 For more information about images, see [user documentation][images].
@@ -87,9 +87,9 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - The ARN of the image.
 * `id` - The ID of the created image.
 * `root_snapshot_id` - The Snapshot ID for the root volume (for EBS-backed images)
-* `image_owner_alias` - The owner alias (for example, `self`) or the CROC Cloud project ID.
+* `image_owner_alias` - The owner alias (for example, `self`) or the project ID.
 * `image_type` - The type of image.
-* `owner_id` - The CROC Cloud project ID.
+* `owner_id` - The project ID.
 * `platform` - This value is set to windows for Windows images; otherwise, it is blank.
 * `public` - Indicates whether the image has public launch permissions.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block][default-tags].

--- a/website/docs/r/ami.html.markdown
+++ b/website/docs/r/ami.html.markdown
@@ -95,7 +95,7 @@ In addition to all arguments above, the following attributes are exported:
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block][default-tags].
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `boot_mode` - The boot mode of the image. Always `""`.
 * `deprecation_time` - The date and time to deprecate the image. Always `""`.

--- a/website/docs/r/ami_from_instance.html.markdown
+++ b/website/docs/r/ami_from_instance.html.markdown
@@ -58,7 +58,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The ID of the created image.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `snapshot_without_reboot` - Whether the behavior of stopping the instance before snapshotting is overrided. Always empty.
 

--- a/website/docs/r/ami_from_instance.html.markdown
+++ b/website/docs/r/ami_from_instance.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
-page_title: "AWS: aws_ami_from_instance"
+page_title: "aws_ami_from_instance"
 description: |-
   Creates an Amazon Machine Image (AMI) from an EBS-backed EC2 instance
 ---

--- a/website/docs/r/ami_launch_permission.html.markdown
+++ b/website/docs/r/ami_launch_permission.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
-page_title: "AWS: aws_ami_launch_permission"
+page_title: "aws_ami_launch_permission"
 description: |-
   Adds a launch permission to an Amazon Machine Image (AMI).
 ---

--- a/website/docs/r/ami_launch_permission.html.markdown
+++ b/website/docs/r/ami_launch_permission.html.markdown
@@ -24,7 +24,7 @@ resource "aws_ami_launch_permission" "example" {
 ### Public Access
 
 ```terraform
-# CROC Cloud currently restricts adding public access permissions to images. 
+# The cloud currently restricts adding public access permissions to images.
 # Applying the resource must throw an error.
 resource "aws_ami_launch_permission" "example" {
   image_id = "cmi-12345678"
@@ -36,7 +36,7 @@ resource "aws_ami_launch_permission" "example" {
 
 The following arguments are supported:
 
-* `account_id` - (Optional) The CROC Cloud project ID for the launch permission.
+* `account_id` - (Optional) The project ID (`project@customer`) for the launch permission.
 * `group` - (Optional) The name of the group for the launch permission. Valid values: `"all"`.
 * `image_id` - (Required) The ID of the image.
 
@@ -55,7 +55,7 @@ These exported attributes are currently unsupported:
 ## Import
 
 -> **Unsupported operation**
-Import image launch permission is currently unsupported by CROC Cloud
+Import image launch permission is currently unsupported.
 
 Image launch permissions can be imported using `[ACCOUNT-ID|GROUP-NAME]/IMAGE-ID`, e.g.,
 

--- a/website/docs/r/ami_launch_permission.html.markdown
+++ b/website/docs/r/ami_launch_permission.html.markdown
@@ -47,7 +47,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - Launch permission ID.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `organization_arn` - The ARN of an organization for the launch permission. Always `""`.
 * `organizational_unit_arn` - The ARN of an organizational unit for the launch permission. Always `""`.

--- a/website/docs/r/autoscaling_policy.html.markdown
+++ b/website/docs/r/autoscaling_policy.html.markdown
@@ -47,7 +47,7 @@ In addition to all arguments above, the following attributes are exported:
 * `policy_type` - The scaling policy's type.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `estimated_instance_warmup` - The estimated time, in seconds, until a newly launched instance will contribute CloudWatch metrics. Always `0`.
 * `metric_aggregation_type` - The aggregation type for the policy's metrics. Always `""`.

--- a/website/docs/r/autoscaling_policy.html.markdown
+++ b/website/docs/r/autoscaling_policy.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Auto Scaling"
 layout: "aws"
-page_title: "AWS: aws_autoscaling_policy"
+page_title: "aws_autoscaling_policy"
 description: |-
   Provides an Auto Scaling Group resource.
 ---

--- a/website/docs/r/customer_gateway.html.markdown
+++ b/website/docs/r/customer_gateway.html.markdown
@@ -44,7 +44,7 @@ In addition to all arguments above, the following attributes are exported:
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block][default-tags].
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `certificate_arn` - The Amazon Resource Name (ARN) for the customer gateway certificate. Always `""`.
 * `device_name` - A name for the customer gateway device. Always `""`.

--- a/website/docs/r/customer_gateway.html.markdown
+++ b/website/docs/r/customer_gateway.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPN (Site-to-Site)"
 layout: "aws"
-page_title: "AWS: aws_customer_gateway"
+page_title: "aws_customer_gateway"
 description: |-
   Provides a customer gateway inside a VPC. These objects can be
   connected to VPN gateways via VPN connections, and allow you to

--- a/website/docs/r/default_network_acl.html.markdown
+++ b/website/docs/r/default_network_acl.html.markdown
@@ -22,7 +22,7 @@ For more information about network ACLs, see the documentation on [network ACL][
 
 ### Basic Example
 
-The following config gives the Default Network ACL the same rules that CROC Cloud includes but pulls the resource under management by Terraform. This means that any ACL rules added or changed will be detected as drift.
+The following config gives the Default Network ACL the same rules that the cloud includes but pulls the resource under management by Terraform. This means that any ACL rules added or changed will be detected as drift.
 
 ```terraform
 resource "aws_vpc" "mainvpc" {
@@ -113,13 +113,14 @@ resource "aws_default_network_acl" "default" {
 
 ### Removing `aws_default_network_acl` From Your Configuration
 
-Each VPC comes with a default network ACL that cannot be deleted. The `aws_default_network_acl` allows you to manage this Network ACL, but Terraform cannot destroy it. Removing this resource from your configuration will remove it from your statefile and management, **but will not destroy the Network ACL.** All Subnets associations and ingress or egress rules will be left as they are at the time of removal. You can resume managing them via the CROC Cloud Console.
+Each VPC comes with a default network ACL that cannot be deleted. The `aws_default_network_acl` allows you to manage this Network ACL, but Terraform cannot destroy it. Removing this resource from your configuration will remove it from your statefile and management, **but will not destroy the Network ACL.** All Subnets associations and ingress or egress rules will be left as they are at the time of removal. You can resume managing them via the cloud console.
 
 ## Argument Reference
 
 The following arguments are required:
 
-* `default_network_acl_id` - (Required) Network ACL ID to manage. This attribute is exported from `aws_vpc`, or manually found via the CROC Cloud Console.
+* `default_network_acl_id` - (Required) Network ACL ID to manage.
+  This attribute is exported from `aws_vpc`, or manually found via the cloud console.
 
 The following arguments are optional:
 
@@ -161,7 +162,7 @@ In addition to all arguments above, the following attributes are exported:
 These exported attributes are currently unsupported:
 
 * `ipv6_cidr_block` - The IPv6 CIDR block. Always `""`.
-* `owner_id` - ID of the CROC Cloud account that owns the default network ACL. Always `""`.
+* `owner_id` - The ID of the project that owns the default network ACL. Always `""`.
 
 ## Import
 

--- a/website/docs/r/default_network_acl.html.markdown
+++ b/website/docs/r/default_network_acl.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_default_network_acl"
+page_title: "aws_default_network_acl"
 description: |-
   Manage a default network ACL.
 ---

--- a/website/docs/r/default_network_acl.html.markdown
+++ b/website/docs/r/default_network_acl.html.markdown
@@ -158,7 +158,7 @@ In addition to all arguments above, the following attributes are exported:
 * `vpc_id` -  ID of the associated VPC
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `ipv6_cidr_block` - The IPv6 CIDR block. Always `""`.
 * `owner_id` - ID of the CROC Cloud account that owns the default network ACL. Always `""`.

--- a/website/docs/r/default_route_table.html.markdown
+++ b/website/docs/r/default_route_table.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_default_route_table"
+page_title: "aws_default_route_table"
 description: |-
   Provides a resource to manage a default route table of a VPC.
 ---

--- a/website/docs/r/default_route_table.html.markdown
+++ b/website/docs/r/default_route_table.html.markdown
@@ -98,7 +98,7 @@ In addition to all arguments above, the following attributes are exported:
 * `vpc_id` - ID of the VPC.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `destination_prefix_list_id` - ID of a managed prefix list destination of the route. Always `""`.
 * `ipv6_cidr_block` - The Ipv6 CIDR block of the route. Always `""`.

--- a/website/docs/r/default_route_table.html.markdown
+++ b/website/docs/r/default_route_table.html.markdown
@@ -102,7 +102,7 @@ These exported attributes are currently unsupported:
 
 * `destination_prefix_list_id` - ID of a managed prefix list destination of the route. Always `""`.
 * `ipv6_cidr_block` - The Ipv6 CIDR block of the route. Always `""`.
-* `owner_id` - ID of the CROC Cloud account that owns the Default Network ACL. Always `""`.
+* `owner_id` - The ID of the project that owns the Default Network ACL. Always `""`.
 * `route`
     * `core_network_arn` - The ARN of a core network. Always `""`.
     * `egress_only_gateway_id` - ID of a VPC Egress Only Internet Gateway. Always `""`.

--- a/website/docs/r/default_security_group.html.markdown
+++ b/website/docs/r/default_security_group.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_default_security_group"
+page_title: "aws_default_security_group"
 description: |-
   Manage a default security group resource.
 ---

--- a/website/docs/r/default_security_group.html.markdown
+++ b/website/docs/r/default_security_group.html.markdown
@@ -20,7 +20,7 @@ For more information about default security groups, see the documentation on [De
 
 ## Example Usage
 
-The following config gives the default security group the same rules that CROC Cloud provides by default but under management by Terraform. This means that any ingress or egress rules added or changed will be detected as drift.
+The following config gives the default security group the same rules that the cloud provides by default but under management by Terraform. This means that any ingress or egress rules added or changed will be detected as drift.
 
 ```terraform
 resource "aws_vpc" "mainvpc" {
@@ -70,7 +70,7 @@ resource "aws_default_security_group" "example" {
 ### Removing `aws_default_security_group` From Your Configuration
 
 Removing this resource from your configuration will remove it from your statefile and management, but will not destroy the security group.
-All ingress or egress rules will be left as they are at the time of removal. You can resume managing them via the CROC Cloud Console.
+All ingress or egress rules will be left as they are at the time of removal. You can resume managing them via the cloud console.
 
 ## Argument Reference
 
@@ -104,7 +104,7 @@ In addition to all arguments above, the following attributes are exported:
 * `description` - Description of the security group.
 * `id` - ID of the security group.
 * `name` - Name of the security group.
-* `owner_id` - The CROC Cloud project name.
+* `owner_id` - The project ID.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block][default-tags].
 
 ->  **Unsupported attributes**

--- a/website/docs/r/default_security_group.html.markdown
+++ b/website/docs/r/default_security_group.html.markdown
@@ -108,7 +108,7 @@ In addition to all arguments above, the following attributes are exported:
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block][default-tags].
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `prefix_list_ids` - List of prefix list IDs (for allowing access to VPC endpoints). Always empty.
 

--- a/website/docs/r/default_vpc.html.markdown
+++ b/website/docs/r/default_vpc.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_default_vpc"
+page_title: "aws_default_vpc"
 description: |-
   Manage a default VPC resource.
 ---

--- a/website/docs/r/default_vpc.html.markdown
+++ b/website/docs/r/default_vpc.html.markdown
@@ -44,7 +44,7 @@ In addition to all arguments above, the following attributes are exported:
 * `instance_tenancy` - The allowed tenancy of instances launched into the VPC
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `force_destroy` - Whether destroying the resource deletes the default VPC. Always: `false`.
 

--- a/website/docs/r/default_vpc_dhcp_options.html.markdown
+++ b/website/docs/r/default_vpc_dhcp_options.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_default_vpc_dhcp_options"
+page_title: "aws_default_vpc_dhcp_options"
 description: |-
   Manage the default VPC DHCP Options resource.
 ---

--- a/website/docs/r/default_vpc_dhcp_options.html.markdown
+++ b/website/docs/r/default_vpc_dhcp_options.html.markdown
@@ -38,7 +38,7 @@ The following arguments are still supported:
 
 * `netbios_name_servers` - (Optional) List of NETBIOS name servers.
 * `netbios_node_type` - (Optional) The NetBIOS node type (1, 2, 4, or 8). AWS recommends to specify 2 since broadcast and multicast are not supported in their network. For more information about these node types, see [RFC 2132](http://www.ietf.org/rfc/rfc2132.txt).
-* `owner_id` - ID of the CROC Cloud account that owns the DHCP options set.
+* `owner_id` - The ID of the project that owns the DHCP options set.
 * `tags` - (Optional) A map of tags to assign to the resource.
 
 ### Removing `aws_default_vpc_dhcp_options` from your configuration
@@ -46,7 +46,7 @@ The following arguments are still supported:
 The `aws_default_vpc_dhcp_options` resource allows you to manage a region's default DHCP Options Set,
 but Terraform cannot destroy it. Removing this resource from your configuration
 will remove it from your statefile and management, but will not destroy the DHCP Options Set.
-You can resume managing the DHCP Options Set via the CROC Cloud Console.
+You can resume managing the DHCP Options Set via the cloud console.
 
 ## Attributes Reference
 

--- a/website/docs/r/ebs_snapshot.html.markdown
+++ b/website/docs/r/ebs_snapshot.html.markdown
@@ -59,7 +59,7 @@ In addition to all arguments above, the following attributes are exported:
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block][default-tags].
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `data_encryption_key_id` - The data encryption key identifier for the snapshot. Always `""`.
 * `encrypted` - Whether the snapshot is encrypted. Always `false`.

--- a/website/docs/r/ebs_snapshot.html.markdown
+++ b/website/docs/r/ebs_snapshot.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EBS (EC2)"
 layout: "aws"
-page_title: "AWS: aws_ebs_snapshot"
+page_title: "aws_ebs_snapshot"
 description: |-
   Provides an elastic block storage snapshot resource.
 ---

--- a/website/docs/r/ebs_snapshot.html.markdown
+++ b/website/docs/r/ebs_snapshot.html.markdown
@@ -53,7 +53,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `arn` - Amazon Resource Name (ARN) of the EBS snapshot.
 * `id` - The snapshot ID (e.g., snap-12345678).
-* `owner_id` - The CROC Cloud project ID.
+* `owner_id` - The project ID.
 * `owner_alias` - The alias of the EBS snapshot owner.
 * `volume_size` - The size of the drive in GiB.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block][default-tags].

--- a/website/docs/r/ebs_snapshot_import.html.markdown
+++ b/website/docs/r/ebs_snapshot_import.html.markdown
@@ -62,7 +62,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `arn` - Amazon Resource Name (ARN) of the EBS snapshot.
 * `id` - The snapshot ID (e.g., snap-12345678).
-* `owner_id` - The CROC Cloud project ID.
+* `owner_id` - The project ID.
 * `owner_alias` - The alias of the EBS snapshot owner.
 * `volume_size` - The size of the drive in GiB.
 * `tags_all` - A map of tags assigned to the resource.

--- a/website/docs/r/ebs_snapshot_import.html.markdown
+++ b/website/docs/r/ebs_snapshot_import.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EBS (EC2)"
 layout: "aws"
-page_title: "AWS: aws_ebs_snapshot_import"
+page_title: "aws_ebs_snapshot_import"
 description: |-
   Provides an elastic block storage snapshot import resource.
 ---

--- a/website/docs/r/ebs_snapshot_import.html.markdown
+++ b/website/docs/r/ebs_snapshot_import.html.markdown
@@ -68,7 +68,7 @@ In addition to all arguments above, the following attributes are exported:
 * `tags_all` - A map of tags assigned to the resource.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `client_data` - The client-specific data. Always empty.
 * `data_encryption_key_id` - The data encryption key identifier for the snapshot. Always `""`.

--- a/website/docs/r/ebs_volume.html.markdown
+++ b/website/docs/r/ebs_volume.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EBS (EC2)"
 layout: "aws"
-page_title: "AWS: aws_ebs_volume"
+page_title: "aws_ebs_volume"
 description: |-
   Provides an elastic block storage resource.
 ---

--- a/website/docs/r/ebs_volume.html.markdown
+++ b/website/docs/r/ebs_volume.html.markdown
@@ -46,7 +46,7 @@ In addition to all arguments above, the following attributes are exported:
 * `throughput` - The throughput that the volume supports, in MiB/s.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `encrypted` - Whether the disk is encrypted. Always `false`.
 * `kms_key_id` - The ARN for the KMS encryption key. Always `""`.

--- a/website/docs/r/ec2_tag.html.markdown
+++ b/website/docs/r/ec2_tag.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
-page_title: "AWS: aws_ec2_tag"
+page_title: "aws_ec2_tag"
 description: |-
   Manages an individual EC2 resource tag
 ---

--- a/website/docs/r/ec2_transit_gateway.html.markdown
+++ b/website/docs/r/ec2_transit_gateway.html.markdown
@@ -35,7 +35,7 @@ The following arguments are supported:
 * `default_route_table_propagation` - (Optional) Indicates whether the routes are automatically propagated to the default propagation route table.
   Valid values are `disable`, `enable`. Defaults to `enable`.
 * `description` - (Optional) The description of the transit gateway.
-* `shared_owners` - (Optional) List of CROC Cloud account IDs that are granted access to the transit gateway.
+* `shared_owners` - (Optional) List of project IDs (`project@customer`) that are granted access to the transit gateway.
 * `tags` - (Optional) Map of tags to assign to the transit gateway.
   If configured with a provider [`default_tags` configuration block][default-tags] present,
   tags with matching keys will overwrite those defined at the provider-level.
@@ -46,7 +46,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `association_default_route_table_id` - The ID of the default association route table.
 * `id` - The ID of the transit gateway.
-* `owner_id` - The ID of CROC Cloud account that owns the transit gateway.
+* `owner_id` - The ID of the project that owns the transit gateway.
 * `propagation_default_route_table_id` - The ID of the default propagation route table.
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block][default-tags].
 

--- a/website/docs/r/ec2_transit_gateway.html.markdown
+++ b/website/docs/r/ec2_transit_gateway.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Transit Gateway"
 layout: "aws"
-page_title: "CROC Cloud: aws_ec2_transit_gateway"
+page_title: "aws_ec2_transit_gateway"
 description: |-
   Manages a transit gateway.
 ---

--- a/website/docs/r/ec2_transit_gateway.html.markdown
+++ b/website/docs/r/ec2_transit_gateway.html.markdown
@@ -51,7 +51,7 @@ In addition to all arguments above, the following attributes are exported:
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block][default-tags].
 
 ->  **Unsupported attributes**
-These attributes are currently unsupported by CROC Cloud:
+These attributes are currently unsupported:
 
 * `amazon_side_asn` - Private Autonomous System Number (ASN) for the Amazon side of a BGP session. Always `0`.
 * `arn` - The ARN of the transit gateway. Always `""`.

--- a/website/docs/r/ec2_transit_gateway_route.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_route.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Transit Gateway"
 layout: "aws"
-page_title: "CROC Cloud: aws_ec2_transit_gateway_route"
+page_title: "aws_ec2_transit_gateway_route"
 description: |-
   Manages a transit gateway route.
 ---

--- a/website/docs/r/ec2_transit_gateway_route_table.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_route_table.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Transit Gateway"
 layout: "aws"
-page_title: "CROC Cloud: aws_ec2_transit_gateway_route_table"
+page_title: "aws_ec2_transit_gateway_route_table"
 description: |-
   Manages a transit gateway route table.
 ---

--- a/website/docs/r/ec2_transit_gateway_route_table_association.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_route_table_association.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Transit Gateway"
 layout: "aws"
-page_title: "CROC Cloud: aws_ec2_transit_gateway_route_table_association"
+page_title: "aws_ec2_transit_gateway_route_table_association"
 description: |-
   Manages a transit gateway route table association.
 ---

--- a/website/docs/r/ec2_transit_gateway_route_table_propagation.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_route_table_propagation.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Transit Gateway"
 layout: "aws"
-page_title: "CROC Cloud: aws_ec2_transit_gateway_route_table_propagation"
+page_title: "aws_ec2_transit_gateway_route_table_propagation"
 description: |-
   Manages a transit gateway route table propagation.
 ---

--- a/website/docs/r/ec2_transit_gateway_vpc_attachment.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_vpc_attachment.html.markdown
@@ -79,7 +79,7 @@ In addition to all arguments above, the following attributes are exported:
 * `vpc_owner_id` - The ID of CROC Cloud account that owns the VPC.
 
 ->  **Unsupported attributes**
-These attributes are currently unsupported by CROC Cloud:
+These attributes are currently unsupported:
 
 * `appliance_mode_support` - Whether Appliance Mode support is enabled. Always empty.
 * `dns_support` - Whether DNS support is enabled. Always empty.

--- a/website/docs/r/ec2_transit_gateway_vpc_attachment.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_vpc_attachment.html.markdown
@@ -76,7 +76,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the transit gateway attachment.
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block][default-tags].
-* `vpc_owner_id` - The ID of CROC Cloud account that owns the VPC.
+* `vpc_owner_id` - The ID of the project that owns the VPC.
 
 ->  **Unsupported attributes**
 These attributes are currently unsupported:

--- a/website/docs/r/ec2_transit_gateway_vpc_attachment.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_vpc_attachment.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Transit Gateway"
 layout: "aws"
-page_title: "CROC Cloud: aws_ec2_transit_gateway_vpc_attachment"
+page_title: "aws_ec2_transit_gateway_vpc_attachment"
 description: |-
   Manages a transit gateway VPC attachment.
 ---

--- a/website/docs/r/eip.html.markdown
+++ b/website/docs/r/eip.html.markdown
@@ -85,7 +85,7 @@ case both options are defined as the api only requires one or the other.
 
 In addition to all arguments above, the following attributes are exported:
 
-* `allocation_id` - ID that CROC Cloud assigns to represent the allocation of the elastic IP address for use with instances in a VPC.
+* `allocation_id` - ID that the cloud assigns to represent the allocation of the elastic IP address for use with instances in a VPC.
 * `association_id` - ID representing the association of the address with an instance in a VPC.
 * `domain` - Indicates if this EIP is for use in VPC (`vpc`).
 * `id` - Contains the EIP allocation ID.

--- a/website/docs/r/eip.html.markdown
+++ b/website/docs/r/eip.html.markdown
@@ -94,7 +94,7 @@ In addition to all arguments above, the following attributes are exported:
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block][default-tags].
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `carrier_ip` - Carrier IP address. Always `""`.
 * `customer_owned_ip` - Customer owned IP. Always `""`.

--- a/website/docs/r/eip.html.markdown
+++ b/website/docs/r/eip.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
-page_title: "CROC Cloud: aws_eip"
+page_title: "aws_eip"
 description: |-
   Provides an Elastic IP resource.
 ---

--- a/website/docs/r/eip_association.html.markdown
+++ b/website/docs/r/eip_association.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
-page_title: "AWS: aws_eip_association"
+page_title: "aws_eip_association"
 description: |-
   Provides an AWS EIP Association
 ---

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -79,7 +79,7 @@ In addition to all arguments above, the following attributes are exported:
     * `vpc_id` - The VPC associated with your cluster.
 
 ->  **Unsupported attributes**
-These attributes are currently unsupported by CROC Cloud:
+These attributes are currently unsupported:
 
 * `enabled_cluster_log_types` - The enabled control plane logs. Always empty.
 * `encryption_config` - Configuration block with encryption configuration for the cluster. Always empty.

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EKS (Elastic Kubernetes)"
 layout: "aws"
-page_title: "CROC Cloud: aws_eks_cluster"
+page_title: "aws_eks_cluster"
 description: |-
   Manages an EKS cluster.
 ---

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -75,7 +75,7 @@ In addition to all arguments above, the following attributes are exported:
 * `status` - The status of the EKS cluster. One of `CLAIMED`, `CREATING`, `DELETED`, `DELETING`, `ERROR`, `MODIFYING`, `PENDING`, `PROVISIONING`, `READY`, `REPAIRING`.
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block][default-tags].
 * `vpc_config` -  Nested list containing VPC configuration for the cluster.
-    * `cluster_security_group_id` - The cluster security group that was created by CROC Cloud EKS for the cluster.
+    * `cluster_security_group_id` - The cluster security group that was created by the cloud for the cluster.
     * `vpc_id` - The VPC associated with your cluster.
 
 ->  **Unsupported attributes**

--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -140,7 +140,7 @@ In addition to all arguments above, the following attributes are exported:
 * `version` – Kubernetes version.
 
 ->  **Unsupported attributes**
-These attributes are currently unsupported by CROC Cloud:
+These attributes are currently unsupported:
 
 * `ami_type` - Type of image associated with the EKS node group. Always `""`.
 * `force_update_version` - Force version update if existing pods are unable to be drained due to a pod disruption budget issue. Always empty.

--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EKS (Elastic Kubernetes)"
 layout: "aws"
-page_title: "CROC Cloud: aws_eks_node_group"
+page_title: "aws_eks_node_group"
 description: |-
   Manages an EKS node group.
 ---

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
-page_title: "CROC Cloud: aws_instance"
+page_title: "aws_instance"
 description: |-
   Provides an EC2 instance resource. This allows instances to be created, updated, and deleted. Instances also support provisioning.
 ---

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -215,7 +215,7 @@ For `root_block_device`, in addition to the arguments above, the following attri
 * `device_name` - Device name, e.g., `disk1`.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `capacity_reservation_specification` - Describes an instance's Capacity Reservation targeting option. Always empty.
     * `capacity_reservation_preference` - Indicates the instance's Capacity Reservation preferences.

--- a/website/docs/r/key_pair.html.markdown
+++ b/website/docs/r/key_pair.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
-page_title: "AWS: aws_key_pair"
+page_title: "aws_key_pair"
 description: |-
   Provides a Key Pair resource. Currently this supports importing an existing key pair but not creating a new key pair.
 ---

--- a/website/docs/r/key_pair.html.markdown
+++ b/website/docs/r/key_pair.html.markdown
@@ -11,7 +11,7 @@ description: |-
 Provides an EC2 key pair resource. A key pair is used to control login access to EC2 instances.
 
 Currently, this resource requires an existing user-supplied key pair.
-This key pair's public key will be registered with CROC Cloud to allow logging-in to EC2 instances.
+This key pair's public key will be registered to allow logging-in to EC2 instances.
 
 When importing an existing key pair the public key material .
 

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
-page_title: "CROC Cloud: aws_launch_template"
+page_title: "aws_launch_template"
 description: |-
   Provides an EC2 launch template resource. Can be used to create instances or auto scaling groups.
 ---

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -156,7 +156,7 @@ In addition to all arguments above, the following attributes are exported:
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block][default-tags].
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `block_device_mappings`:
     * `ebs`:

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "ELB (Elastic Load Balancing)"
 layout: "aws"
-page_title: "AWS: aws_lb"
+page_title: "aws_lb"
 description: |-
   Provides a Load Balancer resource.
 ---

--- a/website/docs/r/lb_listener.html.markdown
+++ b/website/docs/r/lb_listener.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "ELB (Elastic Load Balancing)"
 layout: "aws"
-page_title: "AWS: aws_lb_listener"
+page_title: "aws_lb_listener"
 description: |-
   Provides a Load Balancer Listener resource.
 ---

--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "ELB (Elastic Load Balancing)"
 layout: "aws"
-page_title: "AWS: aws_lb_target_group"
+page_title: "aws_lb_target_group"
 description: |-
   Provides a Target Group resource for use with Load Balancers.
 ---

--- a/website/docs/r/lb_target_group_attachment.html.markdown
+++ b/website/docs/r/lb_target_group_attachment.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "ELB (Elastic Load Balancing)"
 layout: "aws"
-page_title: "AWS: aws_lb_target_group_attachment"
+page_title: "aws_lb_target_group_attachment"
 description: |-
   Provides the ability to register instances and containers with a LB
   target group

--- a/website/docs/r/main_route_table_association.html.markdown
+++ b/website/docs/r/main_route_table_association.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_main_route_table_association"
+page_title: "aws_main_route_table_association"
 description: |-
   Provides a resource for managing the main routing table of a VPC.
 ---

--- a/website/docs/r/main_route_table_association.html.markdown
+++ b/website/docs/r/main_route_table_association.html.markdown
@@ -47,11 +47,11 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Notes
 
-On VPC creation, the CROC Cloud API always creates an initial Main Route Table. This
+On VPC creation, the cloud always creates an initial Main Route Table. This
 resource records the ID of that Route Table under `original_route_table_id`.
 The "Delete" action for a `main_route_table_association` consists of resetting
 this original table as the Main Route Table for the VPC. You'll see this
-additional Route Table in the CROC Cloud console; it must remain intact in order for
+additional Route Table in the cloud console; it must remain intact in order for
 the `main_route_table_association` delete to work properly.
 
 [route-tables]: https://docs.cloud.croc.ru/en/services/networks/routetables.html

--- a/website/docs/r/network_acl.html.markdown
+++ b/website/docs/r/network_acl.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_network_acl"
+page_title: "aws_network_acl"
 description: |-
   Provides a network ACL resource.
 ---

--- a/website/docs/r/network_acl.html.markdown
+++ b/website/docs/r/network_acl.html.markdown
@@ -97,7 +97,7 @@ In addition to all arguments above, the following attributes are exported:
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block][default-tags].
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `ipv6_cidr_block` - The IPv6 CIDR block. Always `""`.
 * `owner_id` - ID of the CROC Cloud account that owns the Network ACL. Always `""`.

--- a/website/docs/r/network_acl.html.markdown
+++ b/website/docs/r/network_acl.html.markdown
@@ -100,7 +100,7 @@ In addition to all arguments above, the following attributes are exported:
 These exported attributes are currently unsupported:
 
 * `ipv6_cidr_block` - The IPv6 CIDR block. Always `""`.
-* `owner_id` - ID of the CROC Cloud account that owns the Network ACL. Always `""`.
+* `owner_id` - The ID of the project that owns the Network ACL. Always `""`.
 
 ## Import
 

--- a/website/docs/r/network_acl_association.html.markdown
+++ b/website/docs/r/network_acl_association.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_network_acl_association"
+page_title: "aws_network_acl_association"
 description: |-
   Provides a network ACL association resource.
 ---

--- a/website/docs/r/network_acl_rule.html.markdown
+++ b/website/docs/r/network_acl_rule.html.markdown
@@ -70,7 +70,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - ID of the network ACL Rule
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `ipv6_cidr_block` - The IPv6 CIDR block. Always `""`.
 

--- a/website/docs/r/network_acl_rule.html.markdown
+++ b/website/docs/r/network_acl_rule.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_network_acl_rule"
+page_title: "aws_network_acl_rule"
 description: |-
   Provides a network ACL Rule resource.
 ---

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -63,7 +63,7 @@ In addition to all arguments above, the following attributes are exported:
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block][default-tags].
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `interface_type` - Type of network interface to create. Always `"interface"`.
 * `ipv4_prefix_count` - Number of IPv4 prefixes that AWS automatically assigns to the network interface. Always `0`.

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_network_interface"
+page_title: "aws_network_interface"
 description: |-
   Provides an elastic network interface (ENI) resource.
 ---

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -58,7 +58,7 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - ARN of the network interface.
 * `id` - ID of the network interface.
 * `mac_address` - MAC address of the network interface.
-* `owner_id` - The CROC Cloud project ID.
+* `owner_id` - The project ID.
 * `private_dns_name` - Private DNS name of the network interface (IPv4).
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block][default-tags].
 

--- a/website/docs/r/network_interface_attachment.html.markdown
+++ b/website/docs/r/network_interface_attachment.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_network_interface_attachment"
+page_title: "aws_network_interface_attachment"
 description: |-
   Attach an elastic network interface (ENI) resource with EC2 instance.
 ---

--- a/website/docs/r/network_interface_sg_attachment.html.markdown
+++ b/website/docs/r/network_interface_sg_attachment.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_network_interface_sg_attachment"
+page_title: "aws_network_interface_sg_attachment"
 description: |-
   Associates a security group with a network interface.
 ---

--- a/website/docs/r/paas_backup.html.markdown
+++ b/website/docs/r/paas_backup.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "PaaS"
 layout: "aws"
-page_title: "CROC Cloud: aws_paas_backup"
+page_title: "aws_paas_backup"
 description: |-
   Manages a PaaS service backup.
 ---

--- a/website/docs/r/paas_service.html.markdown
+++ b/website/docs/r/paas_service.html.markdown
@@ -272,7 +272,7 @@ resource "aws_subnet" "subnet_comp1p" {
 resource "aws_s3_bucket" "example" {
   bucket = "tf-paas-backup"
 
-  # Use the predefined provider configuration to connect to CROC Cloud object storage
+  # Use the predefined provider configuration to connect to object storage
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 }
@@ -894,7 +894,7 @@ The `monitoring` block has the following structure:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `auto_created_security_group_ids` - List of security group IDs that CROC Cloud created for the service.
+* `auto_created_security_group_ids` - List of security group IDs that the cloud created for the service.
 * `endpoints` - List of endpoints for connecting to the service.
 * `error_code` - The service error code.
 * `error_description` - The detailed description of the service error.

--- a/website/docs/r/paas_service.html.markdown
+++ b/website/docs/r/paas_service.html.markdown
@@ -14,7 +14,7 @@ description: |-
 [doc-transaction_isolation]: https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_transaction_isolation
 
 [paas]: https://docs.cloud.croc.ru/en/services/paas/index.html
-[technical support]: https://support.croc.ru/app/#/project/CS
+[technical support]: https://support.k2int.ru/app/#/project/CS
 [timeouts]: https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts
 
 [Elasticsearch]: #elasticsearch-argument-reference

--- a/website/docs/r/paas_service.html.markdown
+++ b/website/docs/r/paas_service.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "PaaS"
 layout: "aws"
-page_title: "CROC Cloud: aws_paas_service"
+page_title: "aws_paas_service"
 description: |-
   Manages a PaaS service.
 ---

--- a/website/docs/r/placement_group.html.markdown
+++ b/website/docs/r/placement_group.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
-page_title: "AWS: aws_placement_group"
+page_title: "aws_placement_group"
 description: |-
   Provides an EC2 placement group.
 ---

--- a/website/docs/r/placement_group.html.markdown
+++ b/website/docs/r/placement_group.html.markdown
@@ -41,7 +41,7 @@ In addition to all arguments above, the following attributes are exported:
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block][default-tags].
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `partition_count` - The number of partitions to create in the placement group. Always `0`.
 

--- a/website/docs/r/route.html.markdown
+++ b/website/docs/r/route.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_route"
+page_title: "aws_route"
 description: |-
   Provides a resource to create a routing entry in a VPC routing table.
 ---

--- a/website/docs/r/route.html.markdown
+++ b/website/docs/r/route.html.markdown
@@ -49,7 +49,7 @@ In addition to all arguments above, the following attributes are exported:
 ~> **NOTE:** Only the arguments that are configured (one of the above) will be exported as an attribute once the resource is created.
 
 * `id` - Route identifier computed from the routing table identifier and route destination.
-* `instance_owner_id` - The CROC Cloud project ID that owns the EC2 instance.
+* `instance_owner_id` - The project ID that owns the EC2 instance.
 * `origin` - How the route was created - `CreateRouteTable`, `CreateRoute` or `EnableVgwRoutePropagation`.
 * `state` - The state of the route - `active` or `blackhole`.
 

--- a/website/docs/r/route.html.markdown
+++ b/website/docs/r/route.html.markdown
@@ -54,7 +54,7 @@ In addition to all arguments above, the following attributes are exported:
 * `state` - The state of the route - `active` or `blackhole`.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `carrier_gateway_id` - ID of a carrier gateway. Always `""`.
 * `core_network_arn` - ARN of a core network. Always `""`.

--- a/website/docs/r/route53_record.html.markdown
+++ b/website/docs/r/route53_record.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Route 53"
 layout: "aws"
-page_title: "CROC Cloud: aws_route53_record"
+page_title: "aws_route53_record"
 description: |-
   Provides a Route53 record resource.
 ---

--- a/website/docs/r/route53_record.html.markdown
+++ b/website/docs/r/route53_record.html.markdown
@@ -66,7 +66,7 @@ In addition to all arguments above, the following attributes are exported:
 * `fqdn` - [FQDN](https://en.wikipedia.org/wiki/Fully_qualified_domain_name) built using the zone domain and `name`.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `set_identifier` - Unique identifier to differentiate records with routing policies from one another. Always empty.
 * `health_check_id` - The health check the record should be associated with. Always empty.

--- a/website/docs/r/route53_zone.html.markdown
+++ b/website/docs/r/route53_zone.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Route 53"
 layout: "aws"
-page_title: "CROC Cloud: aws_route53_zone"
+page_title: "aws_route53_zone"
 description: |-
   Manages a Route53 Hosted Zone
 ---

--- a/website/docs/r/route53_zone.html.markdown
+++ b/website/docs/r/route53_zone.html.markdown
@@ -87,7 +87,7 @@ In addition to all arguments above, the following attributes are exported:
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `vpc`
     * `vpc_region` - Region of the VPC to associate. Defaults to AWS provider region. Always `""`.

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -107,7 +107,7 @@ attribute once the route resource is created.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block][default-tags].
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `carrier_gateway_id` - ID of a carrier gateway. Always `""`.
 * `destination_prefix_list_id` - ID of a managed prefix list destination of the route. Always `""`.

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_route_table"
+page_title: "aws_route_table"
 description: |-
   Provides a resource to create a VPC routing table.
 ---

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -112,7 +112,7 @@ These exported attributes are currently unsupported:
 * `carrier_gateway_id` - ID of a carrier gateway. Always `""`.
 * `destination_prefix_list_id` - ID of a managed prefix list destination of the route. Always `""`.
 * `ipv6_cidr_block` - The Ipv6 CIDR block of the route. Always `""`.
-* `owner_id` - ID of the CROC Cloud account that owns the Default Network ACL. Always `""`.
+* `owner_id` - The ID of the project that owns the Default Network ACL. Always `""`.
 * `route`
     * `core_network_arn` - ARN of a core network. Always `""`.
     * `egress_only_gateway_id` - ID of a VPC Egress Only Internet Gateway. Always `""`.

--- a/website/docs/r/route_table_association.html.markdown
+++ b/website/docs/r/route_table_association.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_route_table_association"
+page_title: "aws_route_table_association"
 description: |-
   Provides a resource to create an association between a route table and a subnet.
 ---

--- a/website/docs/r/route_table_association.html.markdown
+++ b/website/docs/r/route_table_association.html.markdown
@@ -48,7 +48,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - ID of the association
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `gateway_id` - Gateway ID to create an association. Always `""`.
 

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -55,7 +55,7 @@ Configuring with both will cause inconsistencies and may overwrite configuration
 resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
 
-  # Use the prepared provider configuration to connect to CROC Cloud S3
+  # Use the prepared provider configuration to connect to S3
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 
@@ -81,7 +81,7 @@ resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
   acl    = "public-read"
 
-  # Use the prepared provider configuration to connect to CROC Cloud S3
+  # Use the prepared provider configuration to connect to S3
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 
@@ -113,7 +113,7 @@ resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
   acl    = "public-read"
 
-  # Use the prepared provider configuration to connect to CROC Cloud S3
+  # Use the prepared provider configuration to connect to S3
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 
@@ -137,7 +137,7 @@ resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
   acl    = "private"
 
-  # Use the prepared provider configuration to connect to CROC Cloud S3
+  # Use the prepared provider configuration to connect to S3
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 
@@ -157,7 +157,7 @@ resource "aws_s3_bucket" "bucket" {
   bucket = "tf-example"
   acl    = "private"
 
-  # Use the prepared provider configuration to connect to CROC Cloud S3
+  # Use the prepared provider configuration to connect to S3
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 
@@ -192,7 +192,7 @@ resource "aws_s3_bucket" "versioning_bucket" {
   bucket = "tf-example"
   acl    = "private"
 
-  # Use the prepared provider configuration to connect to CROC Cloud S3
+  # Use the prepared provider configuration to connect to S3
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 
@@ -222,7 +222,7 @@ data "aws_canonical_user_id" "current_user" {}
 resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
 
-  # Use the prepared provider configuration to connect to CROC Cloud S3
+  # Use the prepared provider configuration to connect to S3
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 
@@ -278,7 +278,7 @@ The `cors_rule` configuration block supports the following arguments:
 
 The `grant` configuration block supports the following arguments:
 
-* `id` - (Optional) Canonical user ID to grant for (CROC Cloud S3 User ID). Used only when `type` is `CanonicalUser`.
+* `id` - (Optional) Canonical user ID to grant for (S3 User ID). Used only when `type` is `CanonicalUser`.
 * `type` - (Required) Type of grantee to apply for. Valid values are `CanonicalUser` and `Group`. `AmazonCustomerByEmail` is not supported.
 * `permissions` - (Required) List of permissions to apply for grantee. Valid values are `READ`, `WRITE`, `READ_ACP`, `WRITE_ACP`, `FULL_CONTROL`.
 * `uri` - (Optional) Uri address to grant for. Supported groups are `http://acs.amazonaws.com/groups/global/AllUsers` and `http://acs.amazonaws.com/groups/global/AuthenticatedUsers`. Used only when `type` is `Group`.

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "S3 (Simple Storage)"
 layout: "aws"
-page_title: "CROC Cloud: aws_s3_bucket"
+page_title: "aws_s3_bucket"
 description: |-
   Provides a S3 bucket resource.
 ---

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -340,7 +340,7 @@ In addition to all arguments above, the following attributes are exported:
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block][default-tags].
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `acceleration_status` - Sets the accelerate configuration of an existing bucket. Always `""`.
 * `bucket_domain_name` - The bucket domain name. Contains domain name of format `bucketname.s3.amazonaws.com`.

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -55,7 +55,7 @@ Configuring with both will cause inconsistencies and may overwrite configuration
 resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
 
-  # Use the prepared provider configuration to connect to S3
+  # Use the predefined provider configuration to connect to object storage
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 
@@ -81,7 +81,7 @@ resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
   acl    = "public-read"
 
-  # Use the prepared provider configuration to connect to S3
+  # Use the predefined provider configuration to connect to object storage
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 
@@ -113,7 +113,7 @@ resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
   acl    = "public-read"
 
-  # Use the prepared provider configuration to connect to S3
+  # Use the predefined provider configuration to connect to object storage
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 
@@ -137,7 +137,7 @@ resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
   acl    = "private"
 
-  # Use the prepared provider configuration to connect to S3
+  # Use the predefined provider configuration to connect to object storage
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 
@@ -157,7 +157,7 @@ resource "aws_s3_bucket" "bucket" {
   bucket = "tf-example"
   acl    = "private"
 
-  # Use the prepared provider configuration to connect to S3
+  # Use the predefined provider configuration to connect to object storage
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 
@@ -192,7 +192,7 @@ resource "aws_s3_bucket" "versioning_bucket" {
   bucket = "tf-example"
   acl    = "private"
 
-  # Use the prepared provider configuration to connect to S3
+  # Use the predefined provider configuration to connect to object storage
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 
@@ -222,7 +222,7 @@ data "aws_canonical_user_id" "current_user" {}
 resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
 
-  # Use the prepared provider configuration to connect to S3
+  # Use the predefined provider configuration to connect to object storage
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 

--- a/website/docs/r/s3_bucket_acl.html.markdown
+++ b/website/docs/r/s3_bucket_acl.html.markdown
@@ -25,7 +25,7 @@ For more information about access rights for buckets, see [user documentation][a
 resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
 
-  # Use the prepared provider configuration to connect to S3
+  # Use the predefined provider configuration to connect to object storage
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 }
@@ -44,7 +44,7 @@ data "aws_canonical_user_id" "current" {}
 resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
 
-  # Use the prepared provider configuration to connect to S3
+  # Use the predefined provider configuration to connect to object storage
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 }

--- a/website/docs/r/s3_bucket_acl.html.markdown
+++ b/website/docs/r/s3_bucket_acl.html.markdown
@@ -25,7 +25,7 @@ For more information about access rights for buckets, see [user documentation][a
 resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
 
-  # Use the prepared provider configuration to connect to CROC Cloud S3
+  # Use the prepared provider configuration to connect to S3
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 }
@@ -44,7 +44,7 @@ data "aws_canonical_user_id" "current" {}
 resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
 
-  # Use the prepared provider configuration to connect to CROC Cloud S3
+  # Use the prepared provider configuration to connect to S3
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 }
@@ -108,8 +108,8 @@ The `owner` configuration block supports the following arguments:
 
 The `grantee` configuration block supports the following arguments:
 
-* `email_address` - (Optional) Email address of the grantee (CROC Cloud S3 Project email). Used only when `type` is `AmazonCustomerByEmail`.
-* `id` - (Optional) The canonical user ID of the grantee (CROC Cloud S3 User ID). Used only when `type` is `CanonicalUser`.
+* `email_address` - (Optional) Email address of the grantee (S3 Project email). Used only when `type` is `AmazonCustomerByEmail`.
+* `id` - (Optional) The canonical user ID of the grantee (S3 User ID). Used only when `type` is `CanonicalUser`.
 * `type` - (Required) Type of grantee. Valid values: `CanonicalUser`, `AmazonCustomerByEmail`, `Group`.
 * `uri` - (Optional) URI of the grantee group. Supported groups are `http://acs.amazonaws.com/groups/global/AllUsers` and `http://acs.amazonaws.com/groups/global/AuthenticatedUsers`. Used only when `type` is `Group`.
 

--- a/website/docs/r/s3_bucket_acl.html.markdown
+++ b/website/docs/r/s3_bucket_acl.html.markdown
@@ -120,7 +120,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The `bucket` and `acl` (if configured) separated by commas (`,`).
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `expected_bucket_owner` - The account ID of the expected bucket owner. Always `""`.
 

--- a/website/docs/r/s3_bucket_acl.html.markdown
+++ b/website/docs/r/s3_bucket_acl.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "S3 (Simple Storage)"
 layout: "aws"
-page_title: "CROC Cloud: aws_s3_bucket_acl"
+page_title: "aws_s3_bucket_acl"
 description: |-
   Provides an S3 bucket ACL resource.
 ---

--- a/website/docs/r/s3_bucket_cors_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_cors_configuration.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "S3 (Simple Storage)"
 layout: "aws"
-page_title: "AWS: aws_s3_bucket_cors_configuration"
+page_title: "aws_s3_bucket_cors_configuration"
 description: |-
   Provides an S3 bucket CORS configuration resource.
 ---

--- a/website/docs/r/s3_bucket_cors_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_cors_configuration.html.markdown
@@ -68,7 +68,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The `bucket`.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `expected_bucket_owner` - The account ID of the expected bucket owner. Always `""`.
 

--- a/website/docs/r/s3_bucket_cors_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_cors_configuration.html.markdown
@@ -20,7 +20,7 @@ Provides an S3 bucket CORS configuration resource. For more information about CO
 resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
 
-  # Use the prepared provider configuration to connect to CROC Cloud S3
+  # Use the prepared provider configuration to connect to S3
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 }

--- a/website/docs/r/s3_bucket_cors_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_cors_configuration.html.markdown
@@ -20,7 +20,7 @@ Provides an S3 bucket CORS configuration resource. For more information about CO
 resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
 
-  # Use the prepared provider configuration to connect to S3
+  # Use the predefined provider configuration to connect to object storage
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 }

--- a/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
@@ -34,7 +34,7 @@ The lifecycle rule applies to a subset of objects based on the key name prefix (
 resource "aws_s3_bucket" "bucket" {
   bucket = "tf-example"
 
-  # Use the prepared provider configuration to connect to S3
+  # Use the predefined provider configuration to connect to object storage
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 }
@@ -199,7 +199,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "example" {
 resource "aws_s3_bucket" "versioning_bucket" {
   bucket = "tf-example"
 
-  # Use the prepared provider configuration to connect to S3
+  # Use the predefined provider configuration to connect to object storage
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 }

--- a/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
@@ -34,7 +34,7 @@ The lifecycle rule applies to a subset of objects based on the key name prefix (
 resource "aws_s3_bucket" "bucket" {
   bucket = "tf-example"
 
-  # Use the prepared provider configuration to connect to CROC Cloud S3
+  # Use the prepared provider configuration to connect to S3
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 }
@@ -199,7 +199,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "example" {
 resource "aws_s3_bucket" "versioning_bucket" {
   bucket = "tf-example"
 
-  # Use the prepared provider configuration to connect to CROC Cloud S3
+  # Use the prepared provider configuration to connect to S3
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 }

--- a/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "S3 (Simple Storage)"
 layout: "aws"
-page_title: "CROC Cloud: aws_s3_bucket_lifecycle_configuration"
+page_title: "aws_s3_bucket_lifecycle_configuration"
 description: |-
   Provides a S3 bucket lifecycle configuration resource.
 ---

--- a/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
@@ -307,7 +307,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The `bucket`.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `expected_bucket_owner` - The account ID of the expected bucket owner. Always `""`.
 * `rule`:

--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -75,7 +75,7 @@ In addition to all arguments above, the following attributes are exported:
 * `version_id` - Unique version ID value for the object, if bucket versioning is enabled.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `bucket_key_enabled` - Whether to use [Amazon S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html) for SSE-KMS. Always `false`.
 * `force_destroy` - Whether to allow the object to be deleted by removing any legal hold on any object version. This value should be set to `true` only if the bucket has S3 object lock enabled. Always `false`.

--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "S3 (Simple Storage)"
 layout: "aws"
-page_title: "CROC Cloud: aws_s3_bucket_object"
+page_title: "aws_s3_bucket_object"
 description: |-
   Provides an S3 object resource.
 ---

--- a/website/docs/r/s3_bucket_policy.html.markdown
+++ b/website/docs/r/s3_bucket_policy.html.markdown
@@ -20,7 +20,7 @@ Attaches a policy to an S3 bucket resource.
 resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
 
-  # Use the prepared provider configuration to connect to CROC Cloud S3
+  # Use the prepared provider configuration to connect to S3
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 }
@@ -54,7 +54,7 @@ The following arguments are supported:
 * `bucket` - (Required) The name of the bucket to which to apply the policy.
 * `policy` - (Required) The text of the policy. Bucket policies are limited to 20 KB in size.
 
-~> **Note:** CROC Cloud S3 API supports Bucket Policy with some limitations.
+~> **Note:** The S3 API supports Bucket Policy with some limitations.
 In particular, you cannot specify a user as Principal, but only the project that owns the bucket.
 Accordingly, all project users will be granted the same permissions.
 For more information about Bucket Policy restrictions, see [user documentation][policy-restrictions].

--- a/website/docs/r/s3_bucket_policy.html.markdown
+++ b/website/docs/r/s3_bucket_policy.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "S3 (Simple Storage)"
 layout: "aws"
-page_title: "CROC Cloud: aws_s3_bucket_policy"
+page_title: "aws_s3_bucket_policy"
 description: |-
   Attaches a policy to an S3 bucket resource.
 ---

--- a/website/docs/r/s3_bucket_policy.html.markdown
+++ b/website/docs/r/s3_bucket_policy.html.markdown
@@ -20,7 +20,7 @@ Attaches a policy to an S3 bucket resource.
 resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
 
-  # Use the prepared provider configuration to connect to S3
+  # Use the predefined provider configuration to connect to object storage
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 }

--- a/website/docs/r/s3_bucket_request_payment_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_request_payment_configuration.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "S3 (Simple Storage)"
 layout: "aws"
-page_title: "AWS: aws_s3_bucket_request_payment_configuration"
+page_title: "aws_s3_bucket_request_payment_configuration"
 description: |-
   Provides an S3 bucket request payment configuration resource.
 ---

--- a/website/docs/r/s3_bucket_request_payment_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_request_payment_configuration.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # Resource: aws_s3_bucket_request_payment_configuration
 
 ->  **Unsupported resource**
-This resource is currently unsupported by CROC Cloud
+This resource is currently unsupported.
 
 Provides an S3 bucket request payment configuration resource. For more information, see [Requester Pays Buckets](https://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html).
 

--- a/website/docs/r/s3_bucket_server_side_encryption_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_server_side_encryption_configuration.html.markdown
@@ -24,7 +24,7 @@ resource "aws_kms_key" "mykey" {
 resource "aws_s3_bucket" "mybucket" {
   bucket = "mybucket"
 
-  # Use the prepared provider configuration to connect to S3
+  # Use the predefined provider configuration to connect to object storage
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 }

--- a/website/docs/r/s3_bucket_server_side_encryption_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_server_side_encryption_configuration.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # Resource: aws_s3_bucket_server_side_encryption_configuration
 
 ->  **Unsupported resource**
-This resource is currently unsupported by CROC Cloud
+This resource is currently unsupported.
 
 Provides a S3 bucket server-side encryption configuration resource.
 
@@ -24,7 +24,7 @@ resource "aws_kms_key" "mykey" {
 resource "aws_s3_bucket" "mybucket" {
   bucket = "mybucket"
 
-  # Use the prepared provider configuration to connect to CROC Cloud S3
+  # Use the prepared provider configuration to connect to S3
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 }

--- a/website/docs/r/s3_bucket_server_side_encryption_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_server_side_encryption_configuration.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "S3 (Simple Storage)"
 layout: "aws"
-page_title: "AWS: aws_s3_bucket_server_side_encryption_configuration"
+page_title: "aws_s3_bucket_server_side_encryption_configuration"
 description: |-
   Provides a S3 bucket server-side encryption configuration resource.
 ---

--- a/website/docs/r/s3_bucket_versioning.html.markdown
+++ b/website/docs/r/s3_bucket_versioning.html.markdown
@@ -121,7 +121,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The `bucket`.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `expected_bucket_owner` - The account ID of the expected bucket owner. Always `""`.
 * `mfa` - The concatenation of the authentication device's serial number, a space, and the value that is displayed on your authentication device. Always empty.

--- a/website/docs/r/s3_bucket_versioning.html.markdown
+++ b/website/docs/r/s3_bucket_versioning.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "S3 (Simple Storage)"
 layout: "aws"
-page_title: "CROC Cloud: aws_s3_bucket_versioning"
+page_title: "aws_s3_bucket_versioning"
 description: |-
   Provides an S3 bucket versioning resource.
 ---

--- a/website/docs/r/s3_bucket_versioning.html.markdown
+++ b/website/docs/r/s3_bucket_versioning.html.markdown
@@ -24,7 +24,7 @@ For more information about S3 versioning, see [user documentation][s3-versioning
 resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
 
-  # Use the prepared provider configuration to connect to CROC Cloud S3
+  # Use the prepared provider configuration to connect to S3
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 }
@@ -48,7 +48,7 @@ resource "aws_s3_bucket_versioning" "versioning_example" {
 resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
 
-  # Use the prepared provider configuration to connect to CROC Cloud S3
+  # Use the prepared provider configuration to connect to S3
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 }
@@ -78,7 +78,7 @@ This example shows the `aws_s3_object.example` depending implicitly on the versi
 resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
 
-  # Use the prepared provider configuration to connect to CROC Cloud S3
+  # Use the prepared provider configuration to connect to S3
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 }

--- a/website/docs/r/s3_bucket_versioning.html.markdown
+++ b/website/docs/r/s3_bucket_versioning.html.markdown
@@ -24,7 +24,7 @@ For more information about S3 versioning, see [user documentation][s3-versioning
 resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
 
-  # Use the prepared provider configuration to connect to S3
+  # Use the predefined provider configuration to connect to object storage
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 }
@@ -48,7 +48,7 @@ resource "aws_s3_bucket_versioning" "versioning_example" {
 resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
 
-  # Use the prepared provider configuration to connect to S3
+  # Use the predefined provider configuration to connect to object storage
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 }
@@ -78,7 +78,7 @@ This example shows the `aws_s3_object.example` depending implicitly on the versi
 resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
 
-  # Use the prepared provider configuration to connect to S3
+  # Use the predefined provider configuration to connect to object storage
   # https://docs.cloud.croc.ru/en/api/tools/terraform.html#providers-tf
   provider = aws.noregion
 }

--- a/website/docs/r/s3_bucket_website_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_website_configuration.html.markdown
@@ -100,7 +100,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The `bucket`.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `expected_bucket_owner` - The account ID of the expected bucket owner. Always `""`.
 * `redirect`:

--- a/website/docs/r/s3_bucket_website_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_website_configuration.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "S3 (Simple Storage)"
 layout: "aws"
-page_title: "CROC Cloud: aws_s3_bucket_website_configuration"
+page_title: "aws_s3_bucket_website_configuration"
 description: |-
   Provides an S3 bucket website configuration resource.
 ---

--- a/website/docs/r/s3_object.html.markdown
+++ b/website/docs/r/s3_object.html.markdown
@@ -73,7 +73,7 @@ In addition to all arguments above, the following attributes are exported:
 * `version_id` - Unique version ID value for the object, if bucket versioning is enabled.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `bucket_key_enabled` - Whether to use [Amazon S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html) for SSE-KMS. Always `false`.
 * `force_destroy` - Whether to allow the object to be deleted by removing any legal hold on any object version. This value should be set to `true` only if the bucket has S3 object lock enabled. Always `false`.

--- a/website/docs/r/s3_object.html.markdown
+++ b/website/docs/r/s3_object.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "S3 (Simple Storage)"
 layout: "aws"
-page_title: "CROC Cloud: aws_s3_object"
+page_title: "aws_s3_object"
 description: |-
   Provides an S3 object resource.
 ---

--- a/website/docs/r/s3_object_copy.html.markdown
+++ b/website/docs/r/s3_object_copy.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "S3 (Simple Storage)"
 layout: "aws"
-page_title: "CROC Cloud: aws_s3_object_copy"
+page_title: "aws_s3_object_copy"
 description: |-
   Provides a resource for copying an S3 object.
 ---

--- a/website/docs/r/s3_object_copy.html.markdown
+++ b/website/docs/r/s3_object_copy.html.markdown
@@ -52,8 +52,8 @@ This configuration block has the following required arguments:
 
 This configuration block has the following optional arguments (one of the three is required):
 
-* `email` - (Optional) Email address of the grantee (CROC Cloud S3 Project email). Used only when `type` is `AmazonCustomerByEmail`.
-* `id` - (Optional) The canonical user ID of the grantee (CROC Cloud S3 User ID). Used only when `type` is `CanonicalUser`.
+* `email` - (Optional) Email address of the grantee (S3 Project email). Used only when `type` is `AmazonCustomerByEmail`.
+* `id` - (Optional) The canonical user ID of the grantee (S3 User ID). Used only when `type` is `CanonicalUser`.
 * `uri` - (Optional) URI of the grantee group. Supported groups are `http://acs.amazonaws.com/groups/global/AllUsers` and `http://acs.amazonaws.com/groups/global/AuthenticatedUsers`. Used only when `type` is `Group`.
 
 -> **Note:** Terraform ignores all leading `/`s in the object's `key` and treats multiple `/`s in the rest of the object's `key` as a single `/`, so values of `/index.html` and `index.html` correspond to the same S3 object as do `first//second///third//` and `first/second/third/`.

--- a/website/docs/r/s3_object_copy.html.markdown
+++ b/website/docs/r/s3_object_copy.html.markdown
@@ -68,7 +68,7 @@ In addition to all arguments above, the following attributes are exported:
 * `version_id` - Version ID of the newly created copy.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `cache_control` - Specifies caching behavior along the request/reply chain. Read [w3c cache_control] for further details. Always `""`.
 * `content_disposition` - Specifies presentational information for the object. Read [w3c content_disposition] for further information. Always `""`.

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -146,7 +146,7 @@ In addition to all arguments above, the following attributes are exported:
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block][default-tags].
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `prefix_list_ids` - List of prefix list IDs (for allowing access to VPC endpoints). Always empty.
 

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_security_group"
+page_title: "aws_security_group"
 description: |-
   Provides a security group resource.
 ---

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -54,7 +54,7 @@ resource "aws_security_group" "allow_tls" {
 }
 ```
 
-~> **NOTE on Egress rules:** By default, CROC Cloud creates an `ALLOW ALL` egress rule when creating a new security group inside a VPC. When creating a new Security Group inside a VPC, **Terraform will remove this default rule**, and require you specifically re-create it if you desire that rule. We feel this leads to fewer surprises in terms of controlling your egress rules. If you desire this rule to be in place, you can use this `egress` block:
+~> **NOTE on Egress rules:** By default, the cloud creates an `ALLOW ALL` egress rule when creating a new security group inside a VPC. When creating a new Security Group inside a VPC, **Terraform will remove this default rule**, and require you specifically re-create it if you desire that rule. We feel this leads to fewer surprises in terms of controlling your egress rules. If you desire this rule to be in place, you can use this `egress` block:
 
 ```terraform
 resource "aws_security_group" "example" {
@@ -142,7 +142,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `arn` - ARN of the security group.
 * `id` - ID of the security group.
-* `owner_id` - The CROC Cloud project name.
+* `owner_id` - The project ID.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block][default-tags].
 
 ->  **Unsupported attributes**

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -71,7 +71,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - ID of the security group rule.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `prefix_list_ids` - List of prefix list IDs (for allowing access to VPC endpoints). Always empty.
 

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -78,7 +78,7 @@ These exported attributes are currently unsupported:
 ## Import
 
 -> **Unsupported operation**
-Import security group rules is currently unsupported by CROC Cloud
+Import security group rules is currently unsupported.
 
 Security group rules can be imported using the `security_group_id`, `type`, `protocol`, `from_port`, `to_port`, and source(s)/destination(s) (e.g., `cidr_block`) separated by underscores (`_`). All parts are required.
 

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_security_group_rule"
+page_title: "aws_security_group_rule"
 description: |-
   Provides a security group rule resource.
 ---

--- a/website/docs/r/snapshot_create_volume_permission.html.markdown
+++ b/website/docs/r/snapshot_create_volume_permission.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EBS (EC2)"
 layout: "aws"
-page_title: "AWS: aws_snapshot_create_volume_permission"
+page_title: "aws_snapshot_create_volume_permission"
 description: |-
   Adds create volume permission to an EBS Snapshot
 ---

--- a/website/docs/r/snapshot_create_volume_permission.html.markdown
+++ b/website/docs/r/snapshot_create_volume_permission.html.markdown
@@ -33,7 +33,7 @@ resource "aws_ebs_snapshot" "example_snapshot" {
 The following arguments are supported:
 
 * `snapshot_id` - (required) A snapshot ID.
-* `account_id` - (required) The CROC Cloud project ID (`project@customer`).
+* `account_id` - (required) The project ID (`project@customer`).
 
 ## Attributes Reference
 

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -48,7 +48,7 @@ In addition to all arguments above, the following attributes are exported:
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block][default-tags].
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `arn` - ARN of the subnet. Always `""`.
 * `assign_ipv6_address_on_creation` - Whether an IPv6 address is assigned on creation. Always `false`.

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -62,7 +62,7 @@ These exported attributes are currently unsupported:
 * `map_customer_owned_ip_on_launch` - Whether customer owned IP addresses are assigned on network interface creation. Always `false`.
 * `map_public_ip_on_launch` - Whether public IP addresses are assigned on instance launch. Always `false`.
 * `outpost_arn` - ARN of the Outpost. Always `""`.
-* `owner_id` - ID of the CROC Cloud account that owns the subnet. Always `""`.
+* `owner_id` - The ID of the project that owns the subnet. Always `""`.
 * `private_dns_hostname_type_on_launch` - The type of hostnames assigned to instances in the subnet at launch. Always `""`.
 
 ## Timeouts

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_subnet"
+page_title: "aws_subnet"
 description: |-
   Provides an VPC subnet resource.
 ---

--- a/website/docs/r/volume_attachment.html.markdown
+++ b/website/docs/r/volume_attachment.html.markdown
@@ -55,7 +55,7 @@ In addition to all arguments above, the following attributes are exported:
 * `volume_id` - ID of the volume.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `force_detach` - Whether force volume detaching is enabled. Always empty.
 

--- a/website/docs/r/volume_attachment.html.markdown
+++ b/website/docs/r/volume_attachment.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "EBS (EC2)"
 layout: "aws"
-page_title: "CROC Cloud: aws_volume_attachment"
+page_title: "aws_volume_attachment"
 description: |-
   Provides an EBS Volume Attachment
 ---

--- a/website/docs/r/vpc.html.markdown
+++ b/website/docs/r/vpc.html.markdown
@@ -57,7 +57,7 @@ In addition to all arguments above, the following attributes are exported:
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block][default-tags].
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `assign_generated_ipv6_cidr_block` - (Optional) Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. Always `false`.
 * `enable_classiclink` - Whether the VPC has Classiclink enabled. Always `false`.

--- a/website/docs/r/vpc.html.markdown
+++ b/website/docs/r/vpc.html.markdown
@@ -71,7 +71,7 @@ These exported attributes are currently unsupported:
 * `ipv6_cidr_block_network_border_group` - The Network Border Group Zone name. Always `""`.
 * `ipv6_ipam_pool_id` - IPAM Pool ID for a IPv6 pool. Always `""`.
 * `ipv6_netmask_length` - Netmask length to request from IPAM Pool. Always `0`.
-* `owner_id` - The ID of the CROC Cloud account that owns the VPC. Always `""`.
+* `owner_id` - The ID of the project that owns the VPC. Always `""`.
 
 ## Import
 

--- a/website/docs/r/vpc.html.markdown
+++ b/website/docs/r/vpc.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_vpc"
+page_title: "aws_vpc"
 description: |-
   Provides a VPC resource.
 ---

--- a/website/docs/r/vpc_dhcp_options.html.markdown
+++ b/website/docs/r/vpc_dhcp_options.html.markdown
@@ -66,7 +66,7 @@ In addition to all arguments above, the following attributes are exported:
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block][default-tags].
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported:
 
 * `owner_id` - ID of the CROC Cloud account that owns the DHCP options set.
 

--- a/website/docs/r/vpc_dhcp_options.html.markdown
+++ b/website/docs/r/vpc_dhcp_options.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_vpc_dhcp_options"
+page_title: "aws_vpc_dhcp_options"
 description: |-
   Provides a VPC DHCP Options resource.
 ---

--- a/website/docs/r/vpc_dhcp_options.html.markdown
+++ b/website/docs/r/vpc_dhcp_options.html.markdown
@@ -68,7 +68,7 @@ In addition to all arguments above, the following attributes are exported:
 ->  **Unsupported attributes**
 These exported attributes are currently unsupported:
 
-* `owner_id` - ID of the CROC Cloud account that owns the DHCP options set.
+* `owner_id` - The ID of the project that owns the DHCP options set.
 
 ## Import
 

--- a/website/docs/r/vpc_dhcp_options_association.html.markdown
+++ b/website/docs/r/vpc_dhcp_options_association.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC (Virtual Private Cloud)"
 layout: "aws"
-page_title: "AWS: aws_vpc_dhcp_options_association"
+page_title: "aws_vpc_dhcp_options_association"
 description: |-
   Provides a VPC DHCP Options Association resource.
 ---

--- a/website/docs/r/vpn_gateway_route_propagation.html.markdown
+++ b/website/docs/r/vpn_gateway_route_propagation.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPN (Site-to-Site)"
 layout: "aws"
-page_title: "AWS: aws_vpn_gateway_route_propagation"
+page_title: "aws_vpn_gateway_route_propagation"
 description: |-
   Requests automatic route propagation between a VPN gateway and a route table.
 ---

--- a/website/docs/r/vpn_gateway_route_propagation.html.markdown
+++ b/website/docs/r/vpn_gateway_route_propagation.html.markdown
@@ -16,7 +16,7 @@ propagation not explicitly listed in its value will be removed.
 
 ## Example Usage
 
--> In CROC Cloud the terms VPC, Internet Gateway, VPN Gateway are equivalent
+-> The terms VPC, Internet Gateway, VPN Gateway are equivalent
 
 ```terraform
 resource "aws_vpc" "example" {

--- a/website_unsupported/d_unsupported/autoscaling_groups.html.markdown
+++ b/website_unsupported/d_unsupported/autoscaling_groups.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # Data Source: aws_autoscaling_groups
 
 -> **Unsupported resource**
-This resource is currently unsupported by CROC Cloud
+This resource is currently unsupported.
 
 The Autoscaling Groups data source allows access to the list of AWS
 ASGs within a specific region. This will allow you to pass a list of AutoScaling Groups to other resources.

--- a/website_unsupported/d_unsupported/cloudtrail_service_account.html.markdown
+++ b/website_unsupported/d_unsupported/cloudtrail_service_account.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # Data Source: aws_cloudtrail_service_account
 
 -> **Unsupported resource**
-This resource is currently unsupported by CROC Cloud
+This resource is currently unsupported.
 
 Use this data source to get the Account ID of the [AWS CloudTrail Service Account](http://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-supported-regions.html)
 in a given region for the purpose of allowing CloudTrail to store trail data in S3.

--- a/website_unsupported/d_unsupported/internet_gateway.html.markdown
+++ b/website_unsupported/d_unsupported/internet_gateway.html.markdown
@@ -9,11 +9,11 @@ description: |-
 # Data Source: aws_internet_gateway
 
 -> **Unsupported resource**
-This resource is currently unsupported by CROC Cloud
+This resource is currently unsupported.
 
 `aws_internet_gateway` provides details about a specific Internet Gateway.
 
--> In CROC Cloud the terms VPC, Internet Gateway, VPN Gateway are equivalent
+-> The terms VPC, Internet Gateway, VPN Gateway are equivalent
 
 ## Example Usage
 

--- a/website_unsupported/r_unsupported/autoscaling_group.html.markdown
+++ b/website_unsupported/r_unsupported/autoscaling_group.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # Resource: aws_autoscaling_group
 
 -> **Unsupported resource**
-This resource is currently unsupported by CROC Cloud
+This resource is currently unsupported.
 
 Provides an Auto Scaling Group resource.
 

--- a/website_unsupported/r_unsupported/autoscaling_group_tag.html.markdown
+++ b/website_unsupported/r_unsupported/autoscaling_group_tag.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # Resource: aws_autoscaling_group_tag
 
 -> **Unsupported resource**
-This resource is currently unsupported by CROC Cloud
+This resource is currently unsupported.
 
 Manages an individual Autoscaling Group (ASG) tag. This resource should only be used in cases where ASGs are created outside Terraform (e.g., ASGs implicitly created by EKS Node Groups).
 

--- a/website_unsupported/r_unsupported/cloudtrail.html.markdown
+++ b/website_unsupported/r_unsupported/cloudtrail.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # Resource: aws_cloudtrail
 
 -> **Unsupported resource**
-This resource is currently unsupported by CROC Cloud
+This resource is currently unsupported.
 
 Provides a CloudTrail resource.
 

--- a/website_unsupported/r_unsupported/cloudwatch_metric_alarm.html.markdown
+++ b/website_unsupported/r_unsupported/cloudwatch_metric_alarm.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # Resource: aws_cloudwatch_metric_alarm
 
 -> **Unsupported resource**
-This resource is currently unsupported by CROC Cloud
+This resource is currently unsupported.
 
 Provides a CloudWatch Metric Alarm resource.
 

--- a/website_unsupported/r_unsupported/default_subnet.html.markdown
+++ b/website_unsupported/r_unsupported/default_subnet.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # Resource: aws_default_subnet
 
 -> **Unsupported resource**
-This resource is currently unsupported by CROC Cloud
+This resource is currently unsupported.
 
 Provides a resource to manage a [default subnet](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/default-vpc.html#default-vpc-basics) in the current region.
 

--- a/website_unsupported/r_unsupported/internet_gateway.html.markdown
+++ b/website_unsupported/r_unsupported/internet_gateway.html.markdown
@@ -9,11 +9,11 @@ description: |-
 # Resource: aws_internet_gateway
 
 -> **Unsupported resource**
-This resource is currently unsupported by CROC Cloud
+This resource is currently unsupported.
 
 Provides a resource to create a VPC Internet Gateway.
 
--> In CROC Cloud the terms VPC, Internet Gateway, VPN Gateway are equivalent
+-> The terms VPC, Internet Gateway, VPN Gateway are equivalent
 
 ## Example Usage
 

--- a/website_unsupported/r_unsupported/vpn_connection.html.markdown
+++ b/website_unsupported/r_unsupported/vpn_connection.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPN (Site-to-Site)"
 layout: "aws"
-page_title: "CROC Cloud: aws_vpn_connection"
+page_title: "aws_vpn_connection"
 description: |-
   Manages a Site-to-Site VPN connection. A Site-to-Site VPN connection is an Internet Protocol security (IPSec) VPN connection between a VPC and an on-premises network.
 ---
@@ -13,7 +13,7 @@ description: |-
 # Resource: aws_vpn_connection
 
 -> **Unsupported resource**
-This resource is currently unsupported by CROC Cloud
+This resource is currently unsupported.
 
 Manages a Site-to-Site VPN connection. A Site-to-Site VPN connection is an Internet Protocol security (IPSec) VPN connection between a VPC and an on-premises network.
 
@@ -24,7 +24,7 @@ For more information about VPN connections, see [user documentation][vpn-connect
 
 ~> **Note:** The CIDR blocks in the arguments `tunnel1_inside_cidr` and `tunnel2_inside_cidr` must have a prefix of /30 and be a part of a specific range.
 
--> In CROC Cloud the terms VPC, Internet Gateway, VPN Gateway are equivalent
+-> The terms VPC, Internet Gateway, VPN Gateway are equivalent
 
 ## Example Usage
 
@@ -70,7 +70,7 @@ The following arguments are required:
 Other arguments:
 
 * `local_ipv4_network_cidr` - (Optional, Default `0.0.0.0/0`) The IPv4 CIDR on the customer gateway (on-premises) side of the VPN connection. Valid value must not fall within the range of 169.254.0.0/16.
-* `remote_ipv4_network_cidr` - (Optional, Default `0.0.0.0/0`) The IPv4 CIDR on the CROC Cloud side of the VPN connection. Valid value must not fall within the range of 169.254.0.0/16.
+* `remote_ipv4_network_cidr` - (Optional, Default `0.0.0.0/0`) The IPv4 CIDR on the cloud side of the VPN connection. Valid value must not fall within the range of 169.254.0.0/16.
 * `tags` - (Optional) Tags to apply to the connection. If configured with a provider [`default_tags` configuration block][default-tags] present, tags with matching keys will overwrite those defined at the provider-level.
 * `tunnel1_ike_versions` - (Optional) The IKE versions that are permitted for the first VPN tunnel. Valid values are `ikev1 | ikev2`.
 * `tunnel2_ike_versions` - (Optional) The IKE versions that are permitted for the second VPN tunnel. Valid values are `ikev1 | ikev2`.
@@ -134,7 +134,7 @@ In addition to all arguments above, the following attributes are exported:
 * `status_message` - If an error occurs, a description of the error.
 
 ->  **Unsupported attributes**
-These exported attributes are currently unsupported by CROC Cloud:
+These exported attributes are currently unsupported.:
 
 * `core_network_arn` - The ARN of the core network. Always `""`.
 * `core_network_attachment_arn` - The ARN of the core network attachment. Always `""`.


### PR DESCRIPTION
NOTES:
- Rockit Cloud rebranding

DOCUMENTATION FIXES:
- datasource/aws_ami, datasource/aws_ami_ids: `executable_users` description: add `all` to the list of possible values
- datasource/aws_ebs_snapshot, datasource/aws_ebs_snapshot_ids: `owners` description: add `self` to the list of possible values