### PR TITLE
Release v24.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+## 24.1.0
+
+NOTES:
+
+* Rockit Cloud rebranding
+
+FEATURES:
+
+* **New Data Source:** `aws_ec2_host`
+
+ENHANCEMENTS:
+
+
+* datasource/aws_route53_zone: make the `IsTruncated` parameter optional as it is not supported
+* datasource/aws_instance: add `tenancy`, `affinity` and `host_id` attributes support
+* resource/aws_route53_record: remove the `StartRecordName`, `StartRecordType`, `MaxItems` parameters as they are not supported
+* resource/aws_instance: add `tenancy`, `affinity` and `host_id` arguments support
+* resource/aws_launch_template: add `tenancy`, `affinity` and `host_id` arguments of the `placement` block support
+* resource/aws_ami: update possible virtualization type values and the default value
+* resource/aws_ami: update volume type default value
+
+DOCUMENTATION FIXES:
+
+* datasource/aws_ami, datasource/aws_ami_ids: `executable_users` description: add `all` to the list of possible values
+* datasource/aws_ebs_snapshot, datasource/aws_ebs_snapshot_ids: `owners` description: add `self` to the list of possible values
+* resource/aws_route53_record: fix description in documentation about records that contain more than 255 characters
+
 ## 24.0.1
 
 BUG FIXES:

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/hashicorp/terraform-provider-aws
 
 go 1.17
 
-replace github.com/aws/aws-sdk-go => github.com/C2Devel/aws-sdk-go v1.44.10-CROC8
+replace github.com/aws/aws-sdk-go => github.com/C2Devel/aws-sdk-go v1.44.10-ROCKIT9
 
 require (
 	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/C2Devel/aws-sdk-go v1.44.10-CROC8 h1:drj63d7mpH61by8PaQ0NJ3BwXt1GEpHWY63Yfyf/8WQ=
-github.com/C2Devel/aws-sdk-go v1.44.10-CROC8/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
+github.com/C2Devel/aws-sdk-go v1.44.10-ROCKIT9 h1:n6qZsJJkzqYOntjuLpeuadsPp4iNPmvYQRpmz4zBnGY=
+github.com/C2Devel/aws-sdk-go v1.44.10-ROCKIT9/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=


### PR DESCRIPTION
NOTES:

* Rockit Cloud rebranding

FEATURES:

* **New Data Source:** `aws_ec2_host`

ENHANCEMENTS:


* datasource/aws_route53_zone: make the `IsTruncated` parameter optional as it is not supported
* datasource/aws_instance: add `tenancy`, `affinity` and `host_id` attributes support
* resource/aws_route53_record: remove the `StartRecordName`, `StartRecordType`, `MaxItems` parameters as they are not supported
* resource/aws_instance: add `tenancy`, `affinity` and `host_id` arguments support
* resource/aws_launch_template: add `tenancy`, `affinity` and `host_id` arguments of the `placement` block support
* resource/aws_ami: update possible virtualization type values and the default value
* resource/aws_ami: update volume type default value

DOCUMENTATION FIXES:

* datasource/aws_ami, datasource/aws_ami_ids: `executable_users` description: add `all` to the list of possible values
* datasource/aws_ebs_snapshot, datasource/aws_ebs_snapshot_ids: `owners` description: add `self` to the list of possible values
* resource/aws_route53_record: fix description in documentation about records that contain more than 255 characters