### PR TITLE
ec2: introduce map_public_ip_on_launch support for subnets

### DIFF
--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -75,8 +75,12 @@ For more information about filtering, see the [EC2 API documentation][describe-s
 
 ## Attributes Reference
 
+In addition to the arguments above, the following attributes are exported:
+
+* `map_public_ip_on_launch` - Indicates whether public IP addresses will be associated with instances created in this subnet. Addresses are associated only if there are available allocated Elastic IP addresses.
+
 ->  **Unsupported attributes**
-In addition to the attributes above, the following attributes are exported but unsupported:
+These attributes are currently unsupported:
 
 * `arn` - ARN of the subnet. Always `""`.
 * `assign_ipv6_address_on_creation` - Whether an IPv6 address is assigned on creation. Always `false`.
@@ -88,7 +92,6 @@ In addition to the attributes above, the following attributes are exported but u
 * `ipv6_cidr_block_association_id` - Association ID of the IPv6 CIDR block. Always `""`.
 * `ipv6_native` - Indicates whether this is an IPv6-only subnet. Always `false`.
 * `map_customer_owned_ip_on_launch` - Whether customer owned IP addresses are assigned on network interface creation. Always `false`.
-* `map_public_ip_on_launch` - Whether public IP addresses are assigned on instance launch. Always `false`.
 * `outpost_arn` - ARN of the Outpost. Always `""`.
 * `owner_id` - The ID of the project that owns the subnet. Always `""`.
 * `private_dns_hostname_type_on_launch` - The type of hostnames assigned to instances in the subnet at launch. Always `""`.

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -37,8 +37,9 @@ The following arguments are supported:
 
 * `availability_zone` - (Optional) AZ for the subnet.
 * `cidr_block` - (Required) The IPv4 CIDR block for the subnet.
-* `vpc_id` - (Required) The VPC ID.
+* `map_public_ip_on_launch` - (Optional) Indicates whether public IP addresses will be associated with instances created in this subnet. Addresses are associated only if there are available allocated Elastic IP addresses. Default is `false`.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block][default-tags] present, tags with matching keys will overwrite those defined at the provider-level.
+* `vpc_id` - (Required) The VPC ID.
 
 ## Attributes Reference
 
@@ -60,7 +61,6 @@ These exported attributes are currently unsupported:
 * `ipv6_cidr_block_association_id` - Association ID of the IPv6 CIDR block. Always `""`.
 * `ipv6_native` - Indicates whether this is an IPv6-only subnet. Always `false`.
 * `map_customer_owned_ip_on_launch` - Whether customer owned IP addresses are assigned on network interface creation. Always `false`.
-* `map_public_ip_on_launch` - Whether public IP addresses are assigned on instance launch. Always `false`.
 * `outpost_arn` - ARN of the Outpost. Always `""`.
 * `owner_id` - The ID of the project that owns the subnet. Always `""`.
 * `private_dns_hostname_type_on_launch` - The type of hostnames assigned to instances in the subnet at launch. Always `""`.


### PR DESCRIPTION
ENHANCEMENTS:

- resource/aws_subnet: Add `map_public_ip_on_launch` argument support.
- data-source/aws_subnet: Add `map_public_ip_on_launch` attribute support.