### PR TITLE
Release v24.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,47 @@
+## 24.2.0
+
+NOTES:
+
+* Bump go version to 1.21
+* readme: add information about GPG key creation process
+
+FEATURES:
+
+* **New Data Source:** `aws_iam_group`
+* **New Data Source:** `aws_iam_policy`
+* **New Data Source:** `aws_iam_project`
+* **New Data Source:** `aws_iam_user`
+* **New Data Source:** `aws_iam_users`
+* **New Data Source:** `aws_backup_plan`
+* **New Data Source:** `aws_backup_selection`
+* **New Data Source:** `aws_backup_vault`
+* **New Resource:** `aws_iam_group`
+* **New Resource:** `aws_iam_group_membership`
+* **New Resource:** `aws_iam_group_policy_attachment`
+* **New Resource:** `aws_iam_policy`
+* **New Resource:** `aws_iam_project`
+* **New Resource:** `aws_iam_user`
+* **New Resource:** `aws_iam_user_group_membership`
+* **New Resource:** `aws_iam_user_policy_attachment`
+* **New Resource:** `aws_cloudwatch_metric_alarm`
+* **New Resource:** `aws_backup_plan`
+* **New Resource:** `aws_backup_selection`
+* **New Resource:** `aws_backup_vault_default`
+
+BUG FIXES:
+
+* resource/aws_customer_gateway, resource/aws_vpn_connection: add `ipsec.legacy` to possible values for `type` argument
+
+ENHANCEMENTS:
+
+* resource/aws_subnet: add `map_public_ip_on_launch` argument support
+* data-source/aws_subnet: add `map_public_ip_on_launch` attribute support
+* provider: change default values for the provider parameters:
+    * `skip_credentials_validation`: set the default value to `true`
+    * `skip_region_validation`: set the default value to `true`
+    * `skip_requesting_account_id`: set the default value to `true`
+* provider: support `EC2_URL` and `PAAS_URL` environment variables
+
 ## 24.1.0
 
 NOTES:

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/hashicorp/terraform-provider-aws
 
 go 1.21
 
-replace github.com/aws/aws-sdk-go => github.com/C2Devel/aws-sdk-go v1.44.10-ROCKIT9
+replace github.com/aws/aws-sdk-go => github.com/C2Devel/aws-sdk-go v1.44.10-ROCKIT10
 
 require (
 	github.com/ProtonMail/go-crypto v1.1.0-alpha.2

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/C2Devel/aws-sdk-go v1.44.10-ROCKIT9 h1:n6qZsJJkzqYOntjuLpeuadsPp4iNPmvYQRpmz4zBnGY=
-github.com/C2Devel/aws-sdk-go v1.44.10-ROCKIT9/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
+github.com/C2Devel/aws-sdk-go v1.44.10-ROCKIT10 h1:L3UUpm3G9ZuZzwoelBQ6jQ7xiDmuQaNTxB4O8AKLV/M=
+github.com/C2Devel/aws-sdk-go v1.44.10-ROCKIT10/go.mod h1:JCfES7rKS8ADm4DcmGHd2i0vL86B2b6rpVPkniCtJX8=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97LyUpzH9P6Hrlg=
@@ -217,7 +217,6 @@ golang.org/x/mod v0.20.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.28.0 h1:a9JDOJc5GMUJ0+UDqmLT86WiEy7iWyIhz8gz8E4e5hE=
 golang.org/x/net v0.28.0/go.mod h1:yqtgsTWOOnlGLG9GFRrK3++bGOUEkNBoHZc8MEDWPNg=
@@ -233,7 +232,6 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
NOTES:

* Bump go version to 1.21
* readme: add information about GPG key creation process

FEATURES:

* **New Data Source:** `aws_iam_group`
* **New Data Source:** `aws_iam_policy`
* **New Data Source:** `aws_iam_project`
* **New Data Source:** `aws_iam_user`
* **New Data Source:** `aws_iam_users`
* **New Data Source:** `aws_backup_plan`
* **New Data Source:** `aws_backup_selection`
* **New Data Source:** `aws_backup_vault`
* **New Resource:** `aws_iam_group`
* **New Resource:** `aws_iam_group_membership`
* **New Resource:** `aws_iam_group_policy_attachment`
* **New Resource:** `aws_iam_policy`
* **New Resource:** `aws_iam_project`
* **New Resource:** `aws_iam_user`
* **New Resource:** `aws_iam_user_group_membership`
* **New Resource:** `aws_iam_user_policy_attachment`
* **New Resource:** `aws_cloudwatch_metric_alarm`
* **New Resource:** `aws_backup_plan`
* **New Resource:** `aws_backup_selection`
* **New Resource:** `aws_backup_vault_default`

BUG FIXES:

* resource/aws_customer_gateway, resource/aws_vpn_connection: add `ipsec.legacy` to possible values for `type` argument

ENHANCEMENTS:

* resource/aws_subnet: add `map_public_ip_on_launch` argument support
* data-source/aws_subnet: add `map_public_ip_on_launch` attribute support
* provider: change default values for the provider parameters:
    * `skip_credentials_validation`: set the default value to `true`
    * `skip_region_validation`: set the default value to `true`
    * `skip_requesting_account_id`: set the default value to `true`
* provider: support `EC2_URL` and `PAAS_URL` environment variables