### PR TITLE
config: replace username with project name in ARN account id

### DIFF
--- a/internal/conns/config.go
+++ b/internal/conns/config.go
@@ -146,8 +146,30 @@ func (c *Config) Client(ctx context.Context) (interface{}, diag.Diagnostics) {
 
 	// FIXME: A temporary solution for building correct ARNs while yet resolving via IAM not implemented
 	if c.SkipCredsValidation && c.SkipRequestingAccountId {
+		errMsg := "The provided access key is in an invalid form: %s. Expected format: project:user@customer."
 		accessKeyParts := strings.Split(c.AccessKey, ":")
-		accountID = accessKeyParts[len(accessKeyParts)-1]
+		if len(accessKeyParts) != 2 {
+			return nil, diag.Errorf(errMsg, c.AccessKey)
+		}
+		projectName := accessKeyParts[0]
+		userLogin := accessKeyParts[1]
+
+		if projectName == "" || userLogin == "" {
+			return nil, diag.Errorf(errMsg, c.AccessKey)
+		}
+
+		userLoginParts := strings.Split(userLogin, "@")
+		if len(userLoginParts) != 2 {
+			return nil, diag.Errorf(errMsg, c.AccessKey)
+		}
+
+		username := userLoginParts[0]
+		customerName := userLoginParts[1]
+		if username == "" || customerName == "" {
+			return nil, diag.Errorf(errMsg, c.AccessKey)
+		}
+
+		accountID = strings.Join([]string{projectName, customerName}, "@")
 		partition = "c2"
 	} else {
 		accountID, partition, err = awsbase.GetAwsAccountIDAndPartition(ctx, cfg, &awsbaseConfig)


### PR DESCRIPTION
BUG FIXES:
- config: fix invalid ARN building that used username instead of project name in accountID section 