### PR TITLE
Release v24.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 24.2.2
+
+BUG FIXES:
+
+* config: fix invalid `ARN` building that used `username` instead of `project name` in `accountID` section
+
 ## 24.2.1
 
 BUG FIXES:


### PR DESCRIPTION
BUG FIXES:

* config: fix invalid `ARN` building that used `username` instead of `project name` in `accountID` section