### PR TITLE
ec2: suppress diff if no lt.placement is specified

### DIFF
--- a/internal/service/ec2/ec2_launch_template.go
+++ b/internal/service/ec2/ec2_launch_template.go
@@ -810,9 +810,10 @@ func ResourceLaunchTemplate() *schema.Resource {
 				},
 			},
 			"placement": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
+				Type:             schema.TypeList,
+				Optional:         true,
+				MaxItems:         1,
+				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"affinity": {


### PR DESCRIPTION
BUG FIXES:

* resource/aws_launch_template: suppress diff if no `placement` block is specified