### PR TITLE
internal: do not validate access key if it is not provided or empty

### DIFF
--- a/internal/conns/config.go
+++ b/internal/conns/config.go
@@ -146,30 +146,34 @@ func (c *Config) Client(ctx context.Context) (interface{}, diag.Diagnostics) {
 
 	// FIXME: A temporary solution for building correct ARNs while yet resolving via IAM not implemented
 	if c.SkipCredsValidation && c.SkipRequestingAccountId {
-		errMsg := "The provided access key is in an invalid form: %s. Expected format: project:user@customer."
-		accessKeyParts := strings.Split(c.AccessKey, ":")
-		if len(accessKeyParts) != 2 {
-			return nil, diag.Errorf(errMsg, c.AccessKey)
-		}
-		projectName := accessKeyParts[0]
-		userLogin := accessKeyParts[1]
+		if c.AccessKey == "" {
+			accountID = ""
+		} else {
+			errMsg := "The provided access key is in an invalid form: %s. Expected format: project:user@customer."
+			accessKeyParts := strings.Split(c.AccessKey, ":")
+			if len(accessKeyParts) != 2 {
+				return nil, diag.Errorf(errMsg, c.AccessKey)
+			}
+			projectName := accessKeyParts[0]
+			userLogin := accessKeyParts[1]
 
-		if projectName == "" || userLogin == "" {
-			return nil, diag.Errorf(errMsg, c.AccessKey)
-		}
+			if projectName == "" || userLogin == "" {
+				return nil, diag.Errorf(errMsg, c.AccessKey)
+			}
 
-		userLoginParts := strings.Split(userLogin, "@")
-		if len(userLoginParts) != 2 {
-			return nil, diag.Errorf(errMsg, c.AccessKey)
-		}
+			userLoginParts := strings.Split(userLogin, "@")
+			if len(userLoginParts) != 2 {
+				return nil, diag.Errorf(errMsg, c.AccessKey)
+			}
 
-		username := userLoginParts[0]
-		customerName := userLoginParts[1]
-		if username == "" || customerName == "" {
-			return nil, diag.Errorf(errMsg, c.AccessKey)
-		}
+			username := userLoginParts[0]
+			customerName := userLoginParts[1]
+			if username == "" || customerName == "" {
+				return nil, diag.Errorf(errMsg, c.AccessKey)
+			}
 
-		accountID = strings.Join([]string{projectName, customerName}, "@")
+			accountID = strings.Join([]string{projectName, customerName}, "@")
+		}
 		partition = "c2"
 	} else {
 		accountID, partition, err = awsbase.GetAwsAccountIDAndPartition(ctx, cfg, &awsbaseConfig)


### PR DESCRIPTION
BUG FIXES:
- internal/conns: do not validate access key if it is not provided or empty because `AWS_ACCESS_KEY_ID` environment variable can be used