### PR TITLE
migrate paas to 4 0 env

### DIFF
--- a/internal/service/paas/service_test.go
+++ b/internal/service/paas/service_test.go
@@ -65,9 +65,7 @@ func TestAccPaaSServiceElasticSearch_basic(t *testing.T) {
 						"kibana":       "false",
 						"logging.#":    "0",
 						"monitoring.#": "0",
-						"options.%":    "0",
-						"password":     "",
-						"version":      "8.2.2",
+						"version":      "8.12",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "endpoints.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "error_code", ""),
@@ -200,7 +198,7 @@ resource "aws_paas_service" "test" {
   ssh_key_name = aws_key_pair.test.key_name
 
   elasticsearch {
-    version = "8.2.2"
+    version = "8.12"
   }
 }
 `, keyName, publicKey, serviceName)

--- a/internal/service/paas/services/mongodb.go
+++ b/internal/service/paas/services/mongodb.go
@@ -72,13 +72,6 @@ func (s mongoDBManager) serviceParametersSchema() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Required: true,
 			ForceNew: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				"3.6.23",
-				"4.0.28",
-				"4.2.23",
-				"4.4.17",
-				"5.0.13",
-			}, false),
 		},
 	}
 }
@@ -128,10 +121,13 @@ func (s mongoDBManager) serviceParametersDataSourceSchema() map[string]*schema.S
 func (s mongoDBManager) userParametersSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"password": {
-			Type:         schema.TypeString,
-			Required:     true,
-			Sensitive:    true,
-			ValidateFunc: validation.StringDoesNotContainAny("`'\"\\"),
+			Type:      schema.TypeString,
+			Required:  true,
+			Sensitive: true,
+			ValidateFunc: validation.All(
+				validation.StringIsNotEmpty,
+				validation.StringDoesNotContainAny("`'\"\\"),
+			),
 		},
 	}
 }

--- a/internal/service/paas/services/rabbitmq.go
+++ b/internal/service/paas/services/rabbitmq.go
@@ -36,15 +36,14 @@ func (s rabbitMQManager) serviceParametersSchema() map[string]*schema.Schema {
 			Required:  true,
 			Sensitive: true,
 			ValidateFunc: validation.All(
-				validation.StringLenBetween(8, 128),
-				validation.StringDoesNotContainAny("`'\"\\"),
+				validation.StringLenBetween(8, 32),
+				validation.StringDoesNotContainAny(`-|[]\'";`),
 			),
 		},
 		"version": {
-			Type:         schema.TypeString,
-			Required:     true,
-			ForceNew:     true,
-			ValidateFunc: validation.StringInSlice([]string{"3.8.30", "3.9.16", "3.10.0"}, false),
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
 		},
 	}
 }

--- a/internal/service/paas/services/redis.go
+++ b/internal/service/paas/services/redis.go
@@ -62,7 +62,7 @@ func (s redisManager) serviceParametersSchema() map[string]*schema.Schema {
 			Sensitive: true,
 			ForceNew:  true,
 			ValidateFunc: validation.All(
-				validation.StringLenBetween(8, 128),
+				validation.StringIsNotEmpty,
 				validation.StringDoesNotContainAny("`'\"\\"),
 			),
 		},
@@ -74,7 +74,7 @@ func (s redisManager) serviceParametersSchema() map[string]*schema.Schema {
 		"persistence_rdb": {
 			Type:     schema.TypeBool,
 			Optional: true,
-			Default:  false,
+			Default:  true,
 		},
 		"timeout": {
 			Type:         schema.TypeInt,
@@ -92,10 +92,9 @@ func (s redisManager) serviceParametersSchema() map[string]*schema.Schema {
 			ValidateFunc: validation.IntAtLeast(0),
 		},
 		"version": {
-			Type:         schema.TypeString,
-			Required:     true,
-			ForceNew:     true,
-			ValidateFunc: validation.StringInSlice([]string{"5.0.14", "6.2.6", "7.0.11"}, false),
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
 		},
 	}
 }

--- a/website/docs/d/paas_service.md
+++ b/website/docs/d/paas_service.md
@@ -282,35 +282,35 @@ the following attributes are exported only for a PostgreSQL service:
 * `autovacuum_vacuum_cost_delay` - The cost delay value in milliseconds used in automatic `VACUUM` operations.
 * `autovacuum_vacuum_cost_limit` - The cost limit value used in automatic `VACUUM` operations.
 * `autovacuum_analyze_scale_factor` - The fraction of the table size to add to `autovacuum_analyze_threshold`
-  when deciding whether to trigger an `ANALYZE`.
+  when deciding whether to trigger `ANALYZE`.
 * `autovacuum_vacuum_scale_factor` - The fraction of the table size to add to `autovacuum_vacuum_threshold`
-  when deciding whether to trigger a `VACUUM`.
+  when deciding whether to trigger `VACUUM`.
 * `class` - The service class.
 * `database` - List of PostgreSQL databases with parameters. The structure of this block is [described below](#postgresql-database).
-* `effective_cache_size` - The planner’s assumption about the effective size of the disk cache
+* `effective_cache_size` - The planner’s assumption about the effective size of the disk cache, in bytes,
   that is available to a single query.
 * `effective_io_concurrency` - The number of concurrent disk I/O operations.
 * `logging` - The logging settings for the service. The structure of this block is [described below](#logging).
-* `maintenance_work_mem` - The maximum amount of memory in bytes used by maintenance operations,
+* `maintenance_work_mem` - The maximum amount of memory, in bytes, used by maintenance operations,
   such as `VACUUM`, `CREATE INDEX`, and `ALTER TABLE ADD FOREIGN KEY`.
 * `max_connections` - The maximum number of simultaneous connections to the database server.
-* `max_wal_size` - The maximum size in bytes that WAL can reach at automatic checkpoints.
+* `max_wal_size` - The maximum size, in bytes, that WAL can reach at automatic checkpoints.
 * `max_parallel_maintenance_workers` - The maximum number of parallel workers that a single utility command can start.
 * `max_parallel_workers` - The maximum number of workers that the system can support for parallel operations.
 * `max_parallel_workers_per_gather` - The maximum number of workers that a single _Gather_ node can start.
 * `max_worker_processes` - The maximum number of background processes that the system can support.
-* `min_wal_size` - The minimum size in bytes to shrink the WAL to. As long as WAL disk usage stays below this setting,
+* `min_wal_size` - The minimum size, in bytes, to shrink the WAL to. As long as WAL disk usage stays below this setting,
   old WAL files are always recycled for future use at a checkpoint, rather than removed.
 * `monitoring` - The monitoring settings for the service. The structure of this block is [described below](#monitoring).
 * `options` - Other PostgreSQL parameters.
 * `replication_mode` - The replication mode in the _Patroni_ cluster.
-* `shared_buffers` - The amount of memory the database server uses for shared memory buffers.
+* `shared_buffers` - The amount of memory, in bytes, the database server uses for shared memory buffers.
 * `user` - List of PostgreSQL users with parameters. The structure of this block is [described below](#postgresql-user).
 * `version` - The installed version.
 * `wal_buffers` - The amount of shared memory used for WAL data not yet written to a volume.
 * `wal_keep_segments` - The minimum number of log files segments that must be kept in the _pg_xlog_ directory,
   in case a standby server needs to fetch them for streaming replication.
-* `work_mem` - The base maximum amount of memory in bytes to be used by a query operation (such as a sort or hash table)
+* `work_mem` - The base maximum amount of memory, in bytes, to be used by a query operation (such as a sort or hash table)
   before writing to temporary disk files.
 
 ### PostgreSQL database

--- a/website/docs/d/paas_service.md
+++ b/website/docs/d/paas_service.md
@@ -202,19 +202,19 @@ the following attributes are exported only for a MySQL service:
 * `connect_timeout` - The number of seconds that the _mysqld_ server waits for a connect packet before responding with **Bad handshake**.
 * `database` - List of MySQL databases with parameters. The structure of this block is [described below](#mysql-database).
 * `galera_options` - Other Galera parameters.
-* `gcache_size` - A Galera parameter. The size of GCache circular buffer storage preallocated on startup in bytes.
+* `gcache_size` - A Galera parameter. The size of GCache circular buffer storage preallocated on startup, in bytes.
 * `gcs_fc_factor` - A Galera parameter. The fraction of `gcs_fc_limit` at which replication is resumed
   when the recv queue length falls below this value.
 * `gcs_fc_limit` - A Galera parameter. The number of writesets. If the recv queue length exceeds it replication is suspended.
 * `gcs_fc_master_slave` - A Galera parameter. Indicates whether the cluster has only one source node.
 * `gcs_fc_single_primary` - A Galera parameter. Indicates whether there is more than one replication source.
 * `innodb_buffer_pool_instances` - The number of regions that `innodb_buffer_pool_size` is divided into when `innodb_buffer_pool_size` > 1 GiB.
-* `innodb_buffer_pool_size` - The size in bytes of the buffer pool used to cache table data and indexes.
+* `innodb_buffer_pool_size` - The size, in bytes, of the buffer pool used to cache table data and indexes.
 * `innodb_change_buffering` - Operations for which change buffering optimization is enabled.
 * `innodb_flush_log_at_trx_commit` - The value of the parameter controls the behaviour for transaction commit operations.
 * `innodb_io_capacity` - The number of I/O operations per second (IOPS) available to InnoDB background tasks.
 * `innodb_io_capacity_max` - The maximum number of IOPS that InnoDB background tasks can perform.
-* `innodb_log_file_size` - The size of a single file in bytes in the redo system log.
+* `innodb_log_file_size` - The size of a single file, in bytes, in the redo system log.
 * `innodb_log_files_in_group` - The number of system log files in a log group.
 * `innodb_purge_threads` - The number of background threads allocated for the InnoDB purge operation.
 * `innodb_thread_concurrency` - The maximum number of threads permitted inside of InnoDB.
@@ -224,7 +224,7 @@ the following attributes are exported only for a MySQL service:
   or any parameter sent by the _mysql_stmt_send_long_data()_ C API function.
 * `max_connect_errors` - The maximum number of connection errors, at which the server blocks the host from further connections.
 * `max_connections` - The maximum permitted number of simultaneous client connections that a host can handle.
-* `max_heap_table_size` - The maximum size in bytes to which user-created `MEMORY` tables are permitted to grow.
+* `max_heap_table_size` - The maximum size, in bytes, to which user-created `MEMORY` tables are permitted to grow.
 * `logging` - The logging settings for the service. The structure of this block is [described below](#logging).
 * `monitoring` - The monitoring settings for the service. The structure of this block is [described below](#monitoring).
 * `options` - Other MySQL parameters.

--- a/website/docs/d/paas_service.md
+++ b/website/docs/d/paas_service.md
@@ -124,6 +124,8 @@ The `root_volume` block has the following structure:
 In addition to the common attributes for all services [described above](#attribute-reference),
 the following attributes are exported only for an Elasticsearch service:
 
+* `allow_anonymous` - Indicates whether anonymous access is enabled.
+* `anonymous_role` - The role for anonymous access.
 * `class` - The service class.
 * `kibana` - Indicates whether the Kibana deployment is enabled.
 * `logging` - The logging settings for the service. The structure of this block is [described below](#logging).

--- a/website/docs/r/paas_service.md
+++ b/website/docs/r/paas_service.md
@@ -16,6 +16,7 @@ description: |-
 [doc-transaction_isolation]: https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_transaction_isolation
 
 [elasticsearch-version]: https://docs.k2.cloud/en/api/paas/parameters/elasticsearch.html#version
+[mongodb-version]: https://docs.k2.cloud/en/api/paas/parameters/mongodb.html#version
 [mysql-version]: https://docs.k2.cloud/en/api/paas/parameters/mysql.html#version
 [paas]: https://docs.cloud.croc.ru/en/services/paas/index.html
 [pgsql-version]: https://docs.k2.cloud/en/api/paas/parameters/pgsql.html#version
@@ -149,7 +150,7 @@ resource "aws_paas_service" "mongodb" {
   ssh_key_name = "<name>"
 
   mongodb {
-    version = "4.2.23"
+    version = "5.0"
 
     journal_commit_interval = 301
     maxconns                = 16
@@ -556,7 +557,8 @@ If you need to use such a parameter, contact [technical support].
 * `quiet` - (Optional, Editable) Indicates whether the quiet mode of _mongos_ or _mongod_ is enabled. Defaults to `false`.
 * `verbositylevel` - (Optional, Editable) The level of message detail in the message log.
   Valid values are `v`, `vv`, `vvv`, `vvvv`, `vvvvv`.
-* `version` - (Required) The version to install. Valid values are `3.6.23`, `4.0.28`, `4.2.23`, `4.4.17`, `5.0.13`.
+* `version` - (Required) The version to install.
+  The list of supported versions is available in the [user documentation][mongodb-version].
 
 ### MongoDB database
 

--- a/website/docs/r/paas_service.md
+++ b/website/docs/r/paas_service.md
@@ -19,6 +19,7 @@ description: |-
 [mysql-version]: https://docs.k2.cloud/en/api/paas/parameters/mysql.html#version
 [paas]: https://docs.cloud.croc.ru/en/services/paas/index.html
 [pgsql-version]: https://docs.k2.cloud/en/api/paas/parameters/pgsql.html#version
+[rabbitmq-version]: https://docs.k2.cloud/en/api/paas/parameters/rabbitmq.html#version
 [technical support]: https://support.k2int.ru/app/#/project/CS
 [timeouts]: https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts
 
@@ -371,7 +372,7 @@ resource "aws_paas_service" "rabbitmq" {
   ssh_key_name = "<name>"
 
   rabbitmq {
-    version  = "3.8.30"
+    version  = "3.10"
     password = "********"
   }
 }
@@ -849,8 +850,9 @@ the `rabbitmq` block can contain the following arguments:
 If you need to use such a parameter, contact [technical support].
 
 * `password` - (Required, Editable) The RabbitMQ admin password.
-  The value must be 8 to 128 characters long and must not contain `'`, `"`, `` ` `` and `\`.
-* `version` - (Required) The version to install. Valid values are `3.8.30`, `3.9.16`, `3.10.0`.
+  The value must be 8 to 32 characters long and must not contain `-`, `|`, `[`, `]`, `'`, `"`, `;` and `\`.
+* `version` - (Required) The version to install.
+  The list of supported versions is available in the [user documentation][rabbitmq-version].
 
 ## Redis Argument Reference
 

--- a/website/docs/r/paas_service.md
+++ b/website/docs/r/paas_service.md
@@ -20,6 +20,7 @@ description: |-
 [paas]: https://docs.cloud.croc.ru/en/services/paas/index.html
 [pgsql-version]: https://docs.k2.cloud/en/api/paas/parameters/pgsql.html#version
 [rabbitmq-version]: https://docs.k2.cloud/en/api/paas/parameters/rabbitmq.html#version
+[redis-version]: https://docs.k2.cloud/en/api/paas/parameters/redis.html#version
 [technical support]: https://support.k2int.ru/app/#/project/CS
 [timeouts]: https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts
 
@@ -405,7 +406,7 @@ resource "aws_paas_service" "redis" {
 
   redis {
     class   = "database"
-    version = "5.0.14"
+    version = "7.2"
 
     password = "********"
 
@@ -873,16 +874,16 @@ the `redis` block can contain the following arguments:
 ~> **Note** If a parameter name includes a dot, it cannot be passed in `options`.
 If you need to use such a parameter, contact [technical support].
 
-* `password` - (Optional) The Redis user password.
-  The value must be 8 to 128 characters long and must not contain `'`, `"`, `` ` `` and `\`.
+* `password` - (Optional) The Redis user password. The value must not contain `'`, `"`, `` ` `` and `\`.
 * `persistence_aof` - (Optional, Editable) Indicates whether the AOF storage mode is enabled. Defaults to `false`.
-* `persistence_rdb` - (Optional, Editable) Indicates whether the RDB storage mode is enabled. Defaults to `false`.
+* `persistence_rdb` - (Optional, Editable) Indicates whether the RDB storage mode is enabled. Defaults to `true`.
 * `timeout` - (Optional, Editable) The time in seconds during which the connection to an inactive client is retained.
   Valid values are from 0 to 2147483647.
 * `tcp_backlog` - (Optional, Editable) The size of a connection queue. Valid values are from 1 to 4096.
 * `tcp_keepalive` - (Optional, Editable) The time in seconds during which the service sends ACKs to detect dead peers (unreachable clients).
   The value must be non-negative.
-* `version` - (Required) The version to install. Valid values are `5.0.14`, `6.2.6`, `7.0.11`.
+* `version` - (Required) The version to install.
+  The list of supported versions is available in the [user documentation][redis-version].
 
 ## Common Service Argument Reference
 

--- a/website/docs/r/paas_service.md
+++ b/website/docs/r/paas_service.md
@@ -6,16 +6,19 @@ description: |-
   Manages a PaaS service.
 ---
 
+[doc-effective_cache_size]: https://postgresqlco.nf/doc/en/param/effective_cache_size/
 [doc-innodb_flush_log_at_trx_commit]: https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_flush_log_at_trx_commit
 [doc-innodb_strict_mode]: https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_strict_mode
 [doc-mariadb-charset-collate]: https://mariadb.com/kb/en/supported-character-sets-and-collations/
 [doc-mysql-charset-collate]: https://dev.mysql.com/doc/refman/8.0/en/charset-charsets.html
 [doc-pxc_strict_mode]: https://docs.percona.com/percona-xtradb-cluster/5.7/features/pxc-strict-mode.html
+[doc-shared_buffers]: https://postgresqlco.nf/doc/en/param/shared_buffers/
 [doc-transaction_isolation]: https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_transaction_isolation
 
 [elasticsearch-version]: https://docs.k2.cloud/en/api/paas/parameters/elasticsearch.html#version
 [mysql-version]: https://docs.k2.cloud/en/api/paas/parameters/mysql.html#version
 [paas]: https://docs.cloud.croc.ru/en/services/paas/index.html
+[pgsql-version]: https://docs.k2.cloud/en/api/paas/parameters/pgsql.html#version
 [technical support]: https://support.k2int.ru/app/#/project/CS
 [timeouts]: https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts
 
@@ -313,14 +316,11 @@ resource "aws_paas_service" "pgsql" {
   }
 
   pgsql {
-    version = "10.21"
+    version = "16"
 
     autovacuum_analyze_scale_factor = 0.3
-    min_wal_size                    = 85 * 1024 * 1024
-    max_wal_size                    = 85 * 1024 * 1024
     work_mem                        = 4 * 1024 * 1024
     maintenance_work_mem            = 1024 * 1024
-    wal_keep_segments               = 0
     replication_mode                = "synchronous"
 
     user {
@@ -733,23 +733,28 @@ the `pgsql` block can contain the following arguments:
 * `autovacuum_vacuum_cost_limit` - (Optional) The cost limit value used in automatic `VACUUM` operations.
   Valid values are `-1`, from 1 to 10000.
 * `autovacuum_analyze_scale_factor` - (Optional) The fraction of the table size to add to `autovacuum_analyze_threshold`
-  when deciding whether to trigger an `ANALYZE`. Valid values are from 0 to 100.
+  when deciding whether to trigger `ANALYZE`. Valid values are from 0 to 100.
 * `autovacuum_vacuum_scale_factor` - (Optional) The fraction of the table size to add to `autovacuum_vacuum_threshold`
-  when deciding whether to trigger a `VACUUM`. Valid values are from 0 to 100.
+  when deciding whether to trigger `VACUUM`. Valid values are from 0 to 100.
 * `class` - (Optional) The service class. Valid value is `database`. Defaults to `database`.
 * `database` - (Optional, Editable) List of PostgreSQL databases with parameters. The maximum number of databases is 1000.
   The structure of this block is [described below](#postgresql-database).
-* `effective_cache_size` - (Optional) The planner’s assumption about the effective size of the disk cache
-  that is available to a single query. Valid values are from 1 to 2147483647.
+* `effective_cache_size` - (Optional) The planner’s assumption about the effective size of the disk cache, in bytes (multiple of 1 KiB),
+  that is available to a single query. Valid values are from 8 to 17179869176 KiB.
+  For more information about the parameter, see the [PostgreSQL documentation][doc-effective_cache_size].
 * `effective_io_concurrency` - (Optional) The number of concurrent disk I/O operations. Valid values are from 0 to 1000.
 * `logging` - (Optional, Editable) The logging settings for the service. The structure of this block is [described below](#logging).
-* `maintenance_work_mem` - (Optional) The maximum amount of memory in bytes (multiple of 1 KiB) used by maintenance operations,
+* `maintenance_work_mem` - (Optional) The maximum amount of memory, in bytes (multiple of 1 KiB), used by maintenance operations,
   such as `VACUUM`, `CREATE INDEX`, and `ALTER TABLE ADD FOREIGN KEY`.
   Valid values are from 1 MiB to 2 GiB.
 * `max_connections` - (Optional) The maximum number of simultaneous connections to the database server.
   Valid values are from 1 to 262143.
-* `max_wal_size` - (Optional) The maximum size in bytes (multiple of 1 MiB) that WAL can reach at automatic checkpoints.
+* `max_wal_size` - (Optional, **Deprecated**) The maximum size, in bytes (multiple of 1 MiB), that WAL can reach at automatic checkpoints.
   Valid values are from 2 to 2147483647 MiB.
+
+~> **Note** The parameter `max_wal_size` is marked as deprecated since it is not supported for PostgreSQL services
+starting with the _paas_v4_0_ environment version.
+
 * `max_parallel_maintenance_workers` - (Optional) The maximum number of parallel workers that a single utility command can start.
   This parameter is relevant only for PostgreSQL versions 11 and higher. Valid values are from 0 to 1024.
 * `max_parallel_workers` - (Optional) The maximum number of workers that the system can support for parallel operations.
@@ -757,9 +762,13 @@ the `pgsql` block can contain the following arguments:
   Valid values are from 0 to 1024.
 * `max_worker_processes` - (Optional) The maximum number of background processes that the system can support.
   Valid values are from 0 to 262143.
-* `min_wal_size` - (Optional) The minimum size in bytes (multiple of 1 MiB) to shrink the WAL to. As long as WAL disk usage stays below this setting,
+* `min_wal_size` - (Optional, **Deprecated**) The minimum size, in bytes (multiple of 1 MiB), to shrink the WAL to. As long as WAL disk usage stays below this setting,
   old WAL files are always recycled for future use at a checkpoint, rather than removed.
   Valid values are from 32 to 2147483647 MiB.
+
+~> **Note** The parameter `min_wal_size` is marked as deprecated since it is not supported for PostgreSQL services
+starting with the _paas_v4_0_ environment version.
+
 * `monitoring` - (Optional, Editable) The monitoring settings for the service. The structure of this block is [described below](#monitoring).
 * `options` - (Optional) Map containing other PostgreSQL parameters.
   Parameter names must be in camelCase. Values are strings.
@@ -769,17 +778,19 @@ If you need to use such a parameter, contact [technical support].
 
 * `replication_mode` - (Optional) The replication mode in the _Patroni_ cluster.
   The parameter must be set if `high_availability` is `true`. Valid values are `asynchronous`, `synchronous`, `synchronous_strict`.
-* `shared_buffers` - (Optional) The amount of memory in 8 KiB pages the database server uses for shared memory buffers.
-  Valid values are from 16 to 1073741823.
+* `shared_buffers` - (Optional) The amount of memory, in bytes (multiple of 1 KiB), the database server uses for shared memory buffers.
+  Valid values are from 128 to 8589934584 KiB.
+  For more information about the parameter, see the [PostgreSQL documentation][doc-shared_buffers].
 * `user` - (Optional, Editable) List of PostgreSQL users with parameters. The maximum number of users is 1000.
   The structure of this block is [described below](#postgresql-user).
-* `version` - (Required) The version to install. Valid values are `10.21`, `11.16`, `12.11`, `13.7`, `14.4`, `15.2`.
+* `version` - (Required) The version to install.
+  The list of supported versions is available in the [user documentation][pgsql-version].
 * `wal_buffers` - (Optional) The amount of shared memory in 8 KiB pages used for WAL data not yet written to a volume.
   Valid values are from 8 to 262143.
 * `wal_keep_segments` - (Optional) The minimum number of log files segments that must be kept in the _pg_xlog_ directory,
   in case a standby server needs to fetch them for streaming replication.
-  This parameter is relevant only for PostgreSQL versions 10, 11, 12. Valid values are from 0 to 2147483647.
-* `work_mem` - (Optional) The base maximum amount of memory in bytes (multiple of 1 KiB) to be used by a query operation
+  This parameter is relevant only for PostgreSQL version 12. Valid values are from 0 to 2147483647.
+* `work_mem` - (Optional) The base maximum amount of memory, in bytes (multiple of 1 KiB), to be used by a query operation
   (such as a sort or hash table) before writing to temporary disk files.
   Valid values are from 64 to 2147483647 KiB.
 
@@ -821,8 +832,7 @@ The `user` block has the following structure:
 The `user` block has the following structure:
 
 * `name` - (Required) The PostgreSQL user name.
-* `password` - (Required) The PostgreSQL user password.
-  The value must be 8 to 128 characters long and must not contain `'`, `"`, `` ` `` and `\`.
+* `password` - (Required) The PostgreSQL user password. The value must not contain `'`, `"`, `` ` `` and `\`.
 
 ## RabbitMQ Argument Reference
 

--- a/website/docs/r/paas_service.md
+++ b/website/docs/r/paas_service.md
@@ -13,6 +13,7 @@ description: |-
 [doc-pxc_strict_mode]: https://docs.percona.com/percona-xtradb-cluster/5.7/features/pxc-strict-mode.html
 [doc-transaction_isolation]: https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_transaction_isolation
 
+[elasticsearch-version]: https://docs.k2.cloud/en/api/paas/parameters/elasticsearch.html#version
 [paas]: https://docs.cloud.croc.ru/en/services/paas/index.html
 [technical support]: https://support.k2int.ru/app/#/project/CS
 [timeouts]: https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts
@@ -73,7 +74,7 @@ resource "aws_paas_service" "elasticsearch" {
   ssh_key_name = "<name>"
 
   elasticsearch {
-    version = "8.2.2"
+    version = "8.12"
     kibana  = true
   }
 }
@@ -496,6 +497,10 @@ The `root_volume` block has the following structure:
 In addition to the common arguments for all services [described above](#argument-reference),
 the `elasticsearch` block can contain the following arguments:
 
+* `allow_anonymous` - (Optional) Indicates whether anonymous access is enabled.
+  The parameter can be set only if `kibana` is `true` and `password` is specified.
+* `anonymous_role` - (Optional) The role for anonymous access. Valid values are `viewer`, `editor`.
+  The parameter can be set only if `allow_anonymous` is `true`.
 * `class` - (Optional) The service class. Valid value is `search`. Defaults to `search`.
 * `kibana` - (Optional) Indicates whether the Kibana deployment is enabled. Defaults to `false`.
 * `logging` - (Optional, Editable) The logging settings for the service. The structure of this block is [described below](#logging).
@@ -507,9 +512,9 @@ the `elasticsearch` block can contain the following arguments:
 If you need to use such a parameter, contact [technical support].
 
 * `password` - (Optional) The Elasticsearch user password.
-  The value must be 8 to 128 characters long and must not contain `-`, `!`, `:`, `;`, `%`, `'`, `"`, `` ` `` and `\`.
+  The value must not contain `-`, `!`, `:`, `;`, `%`, `'`, `"`, `` ` `` and `\`.
 * `version` - (Required) The version to install.
-  Valid values are `7.11.2`, `7.12.1`, `7.13.1`, `7.14.2`, `7.15.2`, `7.16.3`, `7.17.4`, `8.0.1`, `8.1.3`, `8.2.2`.
+  The list of supported versions is available in the [user documentation][elasticsearch-version].
 
 ## Memcached Argument Reference
 

--- a/website/docs/r/paas_service.md
+++ b/website/docs/r/paas_service.md
@@ -65,12 +65,12 @@ resource "aws_paas_service" "elasticsearch" {
   instance_type = "c5.large"
 
   root_volume {
-    type = "st2"
+    type = "gp2"
     size = 32
   }
 
   data_volume {
-    type = "st2"
+    type = "gp2"
     size = 32
   }
 
@@ -97,12 +97,12 @@ resource "aws_paas_service" "memcached" {
   instance_type = "c5.large"
 
   root_volume {
-    type = "st2"
+    type = "gp2"
     size = 32
   }
 
   data_volume {
-    type = "st2"
+    type = "gp2"
     size = 32
   }
 
@@ -134,12 +134,12 @@ resource "aws_paas_service" "mongodb" {
   instance_type = "c5.large"
 
   root_volume {
-    type = "st2"
+    type = "gp2"
     size = 32
   }
 
   data_volume {
-    type = "st2"
+    type = "gp2"
     size = 32
   }
 
@@ -187,12 +187,12 @@ resource "aws_paas_service" "mysql" {
   instance_type = "c5.large"
 
   root_volume {
-    type = "st2"
+    type = "gp2"
     size = 32
   }
 
   data_volume {
-    type = "st2"
+    type = "gp2"
     size = 32
   }
 
@@ -294,12 +294,12 @@ resource "aws_paas_service" "pgsql" {
   instance_type = "c5.large"
 
   root_volume {
-    type = "st2"
+    type = "gp2"
     size = 32
   }
 
   data_volume {
-    type = "st2"
+    type = "gp2"
     size = 32
   }
 
@@ -331,13 +331,18 @@ resource "aws_paas_service" "pgsql" {
       password = "********"
     }
 
+    user {
+      name     = "user2"
+      password = "********"
+    }
+
     database {
       name           = "test_db1"
       owner          = "user1"
       backup_enabled = true
       extensions     = ["bloom", "dict_int"]
       user {
-        name = "user1"
+        name = "user2"
       }
     }
 
@@ -358,7 +363,7 @@ resource "aws_paas_service" "rabbitmq" {
   instance_type = "c5.large"
 
   root_volume {
-    type = "st2"
+    type = "gp2"
     size = 32
   }
 
@@ -390,12 +395,12 @@ resource "aws_paas_service" "redis" {
   instance_type = "c5.large"
 
   root_volume {
-    type = "st2"
+    type = "gp2"
     size = 32
   }
 
   data_volume {
-    type = "st2"
+    type = "gp2"
     size = 32
   }
 

--- a/website/docs/r/paas_service.md
+++ b/website/docs/r/paas_service.md
@@ -14,6 +14,7 @@ description: |-
 [doc-transaction_isolation]: https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_transaction_isolation
 
 [elasticsearch-version]: https://docs.k2.cloud/en/api/paas/parameters/elasticsearch.html#version
+[mysql-version]: https://docs.k2.cloud/en/api/paas/parameters/mysql.html#version
 [paas]: https://docs.cloud.croc.ru/en/services/paas/index.html
 [technical support]: https://support.k2int.ru/app/#/project/CS
 [timeouts]: https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts
@@ -197,7 +198,7 @@ resource "aws_paas_service" "mysql" {
 
   mysql {
     vendor  = "mariadb"
-    version = "10.7.7"
+    version = "10.11"
 
     user {
       name     = "user1"
@@ -595,7 +596,7 @@ the `mysql` block can contain the following arguments:
 ~> **Note** If a parameter name includes a dot, it cannot be passed in `galera_options`.
 If you need to use such a parameter, contact [technical support].
 
-* `gcache_size` - (Optional) A Galera parameter. The size of GCache circular buffer storage preallocated on startup in bytes.
+* `gcache_size` - (Optional) A Galera parameter. The size of GCache circular buffer storage preallocated on startup, in bytes.
   Valid values are from 128 MiB. The parameter can be set only if `high_availability` is `true`.
 * `gcs_fc_factor` - (Optional) A Galera parameter. The fraction of `gcs_fc_limit` at which replication is resumed
   when the recv queue length falls below this value. Valid values are from 0.0 to 1.0.
@@ -606,31 +607,31 @@ If you need to use such a parameter, contact [technical support].
 * `gcs_fc_master_slave` - (Optional) A Galera parameter. Indicates whether the cluster has only one source node.
   The parameter can be set only if `high_availability` is `true`.
 
-~> **Note** `gcs_fc_master_slave` is deprecated. This parameter is relevant for Percona 5.7, MySQL 5.7, and MariaDB 10.2 and 10.3.
+~> **Note** `gcs_fc_master_slave` is deprecated. This parameter is relevant for Percona 5.7.
 Use `gcs_fc_single_primary` instead.
 
 * `gcs_fc_single_primary` - (Optional) A Galera parameter. Indicates whether there is more than one replication source.
   The parameter can be set only if `high_availability` is `true`.
 
 ~> **Note** `gcs_fc_single_primary` replaces the deprecated `gcs_fc_master_slave` parameter.
-This parameter is relevant for Percona 8.0, MySQL 8.0, and MariaDB 10.4, 10.5, 10.6 and 10.7.
+This parameter is relevant for Percona 8.0, MySQL 8.0, and MariaDB 10.4, 10.5, 10.6 and 10.11.
 
 * `innodb_buffer_pool_instances` - (Optional) The number of regions that `innodb_buffer_pool_size` is divided into
   when `innodb_buffer_pool_size` > 1 GiB. This parameter is relevant for Percona 5.7, 8.0 и MariaDB 10.2, 10.3, 10.4.
   Valid values are from 1 to 64.
-* `innodb_buffer_pool_size` - (Optional) The size in bytes of the buffer pool used to cache table data and indexes.
-  Valid values are from 5242880 (5 MiB) to 9223372036854775807.
+* `innodb_buffer_pool_size` - (Optional) The size, in bytes, of the buffer pool used to cache table data and indexes.
+  Valid values are from 128 MiB.
 * `innodb_change_buffering` - (Optional) Operations for which change buffering optimization is enabled.
   Valid values are `inserts`, `deletes`, `changes`, `purges`, `all`, `none`.
 * `innodb_flush_log_at_trx_commit` - (Optional) The value of the parameter controls the behaviour for transaction commit operations.
   Valid values are from 0 to 2.
   For more information about the parameter, see the [MySQL documentation][doc-innodb_flush_log_at_trx_commit].
 * `innodb_io_capacity` - (Optional) The number of I/O operations per second (IOPS) available to InnoDB background tasks.
-  Valid values are from 100 to 9223372036854775807. Defaults to `200`.
+  Valid values are from 100 to 9223372036854775807.
 * `innodb_io_capacity_max` - (Optional) The maximum number of IOPS that InnoDB background tasks can perform.
   Valid values are from 100 to 9223372036854775807.
-* `innodb_log_file_size` - (Optional) The size of a single file in bytes in the redo system log
-  Valid values are from 4 MiB to 512 GiB.
+* `innodb_log_file_size` - (Optional) The size of a single file, in bytes, in the redo system log
+  Valid values are from 4 MiB to 4 GiB.
 * `innodb_log_files_in_group` - (Optional) The number of system log files in a log group.
   Valid values are from 2 to 100.
 * `innodb_purge_threads` - (Optional) The number of background threads allocated for the InnoDB purge operation.
@@ -647,9 +648,9 @@ This parameter is relevant for Percona 8.0, MySQL 8.0, and MariaDB 10.4, 10.5, 1
 * `max_connect_errors` - (Optional) The maximum number of connection errors, at which the server blocks the host from further connections.
   Valid values are from 1 to 9223372036854775807.
 * `max_connections` - (Optional) The maximum permitted number of simultaneous client connections that a host can handle.
-  Valid values are from 1 to 100000.
-* `max_heap_table_size` - (Optional) The maximum size in bytes to which user-created `MEMORY` tables are permitted to grow.
-  Valid values are from 16384 (16 KiB) to 4294966272.
+  Valid values are from 10 to 100000.
+* `max_heap_table_size` - (Optional) The maximum size, in bytes, to which user-created `MEMORY` tables are permitted to grow.
+  Valid values are from 16 KiB to 4 GiB.
 * `logging` - (Optional, Editable) The logging settings for the service. The structure of this block is [described below](#logging).
 * `monitoring` - (Optional, Editable) The monitoring settings for the service. The structure of this block is [described below](#monitoring).
 * `options` - (Optional) Map containing other MySQL parameters.
@@ -665,17 +666,15 @@ If you need to use such a parameter, contact [technical support].
 * `thread_cache_size` - (Optional) The number of threads that the server caches to establish new network connections.
   Valid values are from 0 to 16 KiB.
 * `tmp_table_size` - (Optional) The maximum size of internal in-memory temporary tables in bytes.
-  Valid values are from 1024 to 4294967295.
+  Valid values are from 1 KiB to 4 GiB.
 * `transaction_isolation` - (Optional) The transaction isolation level.
   For more information about the parameter, see the [MySQL documentation][doc-transaction_isolation].
   Valid values are `READ-UNCOMMITTED`, `READ-COMMITTED`, `REPEATABLE-READ`, `SERIALIZABLE`.
 * `user` - (Optional, Editable) List of MySQL users with parameters. The maximum number of users is 1000.
   The structure of this block is [described below](#mysql-user).
 * `vendor` - (Required) The engine vendor. Valid values are `mariadb`, `percona`, `mysql`.
-* `version` - (Required) The version to install. Valid values depend on `vendor`.
-  `mariadb`: `10.2.44`, `10.3.35`, `10.4.25`, `10.5.16`, `10.6.8`, `10.7.7`.
-  `percona`: `5.7.38`, `8.0.28`.
-  `mysql`: `5.7.41`, `8.0.32`.
+* `version` - (Required) The version to install.
+  The list of supported versions is available in the [user documentation][mysql-version].
 * `wait_timeout` - (Optional) The number of seconds the server waits for activity on a noninteractive connection before closing it.
   Valid values are from 1 to 31536000.
 


### PR DESCRIPTION
FEATURES:
* resource/aws_paas_service, data-source/aws_paas_service: support _paas_v4_0_ environment
  * `elasticsearch`:
    * introduce new arguments: `allow_anonymous`, `anonymous_role`
    * add a link to the list of supported Elasticsearch versions in the documentation
    * remove `password` length restrictions 
  * `mongodb`
    * add a link to the list of supported MongoDB versions in the documentation
  * `mysql`
    * add a link to the list of supported MySQL versions in the documentation
    * update valid values for `innodb_buffer_pool_size`, `innodb_log_file_size`, `max_connections`, `max_heap_table_size`, `tmp_table_size`
  * `pgsql`
    * add a link to the list of supported PostgreSQL versions in the documentation
    * update valid values for `effective_cache_size`, `shared_buffers`
    * update the list of supported PostgreSQL versions for `wal_keep_segments`
    * mark `max_wal_size`, `min_wal_size` as deprecated: they are not supported for PostgreSQL services starting with the _paas_v4_0_ environment version
  * `rabbitmq`
    * add a link to the list of supported RabbitMQ versions in the documentation
    * change a default value for `persistence_rdb` to true
    * change max `password` length to 32
  * `redis`
    * add a link to the list of supported Redis versions in the documentation
    * remove `password` length restrictions 