### PR TITLE
eks: fix NotFound errors handling and add and add some retries when creating a cluster or nodegroup

### DIFF
--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -600,7 +600,8 @@ func resourceClusterDelete(d *schema.ResourceData, meta interface{}) error {
 		_, err = conn.DeleteCluster(input)
 	}
 
-	if tfawserr.ErrCodeEquals(err, eks.ErrCodeResourceNotFoundException) {
+	if tfawserr.ErrCodeEquals(err, ErrCodeClusterNotFound) {
+		log.Printf("[WARN] EKS Cluster (%s) not found, removing from state", d.Id())
 		return nil
 	}
 

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -23,6 +23,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
+const (
+	clusterCreateRetryTimeout = 10 * time.Minute
+	clusterDeleteRetryTimeout = 60 * time.Minute
+)
+
 func ResourceCluster() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceClusterCreate,
@@ -331,9 +336,11 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
+	clusterName := d.Get("name").(string)
+
 	log.Printf("[DEBUG] Creating EKS Cluster: %s", input)
 	var output *eks.CreateClusterOutput
-	err := resource.Retry(propagationTimeout, func() *resource.RetryError {
+	err := resource.Retry(clusterCreateRetryTimeout, func() *resource.RetryError {
 		var err error
 
 		output, err = conn.CreateCluster(input)
@@ -359,6 +366,17 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 
 		// InvalidParameterException: IAM role's policy must include the `ec2:DescribeSubnets` action
 		if tfawserr.ErrMessageContains(err, eks.ErrCodeInvalidParameterException, "IAM role's policy must include") {
+			return resource.RetryableError(err)
+		}
+
+		if tfawserr.ErrCodeEquals(err, ErrCodeIPAddressInUse) {
+			log.Printf("[WARN] The specified IP address for EKS Cluster (%s) is in use, trying to create EKS Cluster for some time", clusterName)
+			return resource.RetryableError(err)
+		}
+
+		cluster, _ := FindClusterByName(conn, clusterName)
+		if cluster != nil && aws.StringValue(cluster.Status) == eks.ClusterStatusDeleted {
+			log.Printf("[WARN] EKS Cluster with the same name (%s) found in the DELETED state, waiting for the specified name to become available", clusterName)
 			return resource.RetryableError(err)
 		}
 

--- a/internal/service/eks/consts.go
+++ b/internal/service/eks/consts.go
@@ -3,6 +3,11 @@ package eks
 import "time"
 
 const (
+	ErrCodeClusterNotFound   = "InvalidKubernetesCluster.NotFound"
+	ErrCodeNodegroupNotFound = "InvalidKubernetesNodegroup.NotFound"
+)
+
+const (
 	IdentityProviderConfigTypeOIDC = "oidc"
 )
 

--- a/internal/service/eks/consts.go
+++ b/internal/service/eks/consts.go
@@ -5,6 +5,7 @@ import "time"
 const (
 	ErrCodeClusterNotFound   = "InvalidKubernetesCluster.NotFound"
 	ErrCodeNodegroupNotFound = "InvalidKubernetesNodegroup.NotFound"
+	ErrCodeIPAddressInUse    = "InvalidIPAddress.InUse"
 )
 
 const (

--- a/internal/service/eks/find.go
+++ b/internal/service/eks/find.go
@@ -125,9 +125,7 @@ func FindClusterByName(conn *eks.EKS, name string) (*eks.Cluster, error) {
 
 	output, err := conn.DescribeCluster(input)
 
-	// Sometimes the EKS API returns the ResourceNotFound error in this form:
-	// ClientException: No cluster found for name: tf-acc-test-0o1f8
-	if tfawserr.ErrCodeEquals(err, eks.ErrCodeResourceNotFoundException) || tfawserr.ErrMessageContains(err, eks.ErrCodeClientException, "No cluster found for name:") {
+	if tfawserr.ErrCodeEquals(err, ErrCodeClusterNotFound) {
 		return nil, &resource.NotFoundError{
 			LastError:   err,
 			LastRequest: input,
@@ -214,7 +212,7 @@ func FindNodegroupByClusterNameAndNodegroupName(conn *eks.EKS, clusterName, node
 
 	output, err := conn.DescribeNodegroup(input)
 
-	if tfawserr.ErrCodeEquals(err, eks.ErrCodeResourceNotFoundException) {
+	if tfawserr.ErrCodeEquals(err, ErrCodeNodegroupNotFound) {
 		return nil, &resource.NotFoundError{
 			LastError:   err,
 			LastRequest: input,

--- a/internal/service/eks/node_group.go
+++ b/internal/service/eks/node_group.go
@@ -597,7 +597,8 @@ func resourceNodeGroupDelete(ctx context.Context, d *schema.ResourceData, meta i
 		NodegroupName: aws.String(nodeGroupName),
 	})
 
-	if tfawserr.ErrCodeEquals(err, eks.ErrCodeResourceNotFoundException) {
+	if tfawserr.ErrCodeEquals(err, ErrCodeNodegroupNotFound) {
+		log.Printf("[WARN] EKS Node Group (%s) not found, removing from state", d.Id())
 		return nil
 	}
 

--- a/internal/service/eks/node_group.go
+++ b/internal/service/eks/node_group.go
@@ -22,6 +22,10 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
+const (
+	nodeGroupCreateRetryTimeout = 15 * time.Minute
+)
+
 func ResourceNodeGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceNodeGroupCreate,
@@ -354,7 +358,28 @@ func resourceNodeGroupCreate(ctx context.Context, d *schema.ResourceData, meta i
 		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
-	_, err := conn.CreateNodegroup(input)
+	log.Printf("[DEBUG] Creating EKS Node Group: %s", input)
+	err := resource.Retry(nodeGroupCreateRetryTimeout, func() *resource.RetryError {
+		var err error
+
+		_, err = conn.CreateNodegroup(input)
+
+		nodegroup, _ := FindNodegroupByClusterNameAndNodegroupName(conn, clusterName, nodeGroupName)
+		if nodegroup != nil && aws.StringValue(nodegroup.Status) == eks.NodegroupStatusDeleted {
+			log.Printf("[WARN] EKS Node Group with the same name (%s) found in the DELETED state, waiting for the specified name to become available", nodeGroupName)
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		_, err = conn.CreateNodegroup(input)
+	}
 
 	if err != nil {
 		return diag.Errorf("error creating EKS Node Group (%s): %s", id, err)

--- a/internal/service/eks/wait.go
+++ b/internal/service/eks/wait.go
@@ -100,13 +100,18 @@ func waitClusterCreated(conn *eks.EKS, name string, timeout time.Duration) (*eks
 
 func waitClusterDeleted(conn *eks.EKS, name string, timeout time.Duration) (*eks.Cluster, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{eks.ClusterStatusPending, eks.ClusterStatusClaimed, eks.ClusterStatusDeleting},
-		Target:  []string{eks.ClusterStatusDeleted},
-		Refresh: statusCluster(conn, name),
-		Timeout: timeout,
+		Pending:        []string{eks.ClusterStatusPending, eks.ClusterStatusClaimed, eks.ClusterStatusDeleting},
+		Target:         []string{eks.ClusterStatusDeleted},
+		Refresh:        statusCluster(conn, name),
+		Timeout:        timeout,
+		NotFoundChecks: 1,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
+
+	if tfresource.NotFound(err) {
+		return nil, nil
+	}
 
 	if output, ok := outputRaw.(*eks.Cluster); ok {
 		return output, err
@@ -193,13 +198,18 @@ func waitNodegroupCreated(ctx context.Context, conn *eks.EKS, clusterName, nodeG
 
 func waitNodegroupDeleted(ctx context.Context, conn *eks.EKS, clusterName, nodeGroupName string, timeout time.Duration) (*eks.Nodegroup, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{eks.NodegroupStatusPending, eks.NodegroupStatusDeleting},
-		Target:  []string{eks.NodegroupStatusDeleted},
-		Refresh: statusNodegroup(conn, clusterName, nodeGroupName),
-		Timeout: timeout,
+		Pending:        []string{eks.NodegroupStatusPending, eks.NodegroupStatusDeleting},
+		Target:         []string{eks.NodegroupStatusDeleted},
+		Refresh:        statusNodegroup(conn, clusterName, nodeGroupName),
+		Timeout:        timeout,
+		NotFoundChecks: 1,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if tfresource.NotFound(err) {
+		return nil, nil
+	}
 
 	if output, ok := outputRaw.(*eks.Nodegroup); ok {
 		if status, health := aws.StringValue(output.Status), output.Health; status == eks.NodegroupStatusDeleteFailed && health != nil {

--- a/internal/service/eks/wait.go
+++ b/internal/service/eks/wait.go
@@ -14,8 +14,6 @@ const (
 	addonCreatedTimeout = 20 * time.Minute
 	addonUpdatedTimeout = 20 * time.Minute
 	addonDeletedTimeout = 40 * time.Minute
-
-	clusterDeleteRetryTimeout = 60 * time.Minute
 )
 
 func waitAddonCreated(ctx context.Context, conn *eks.EKS, clusterName, addonName string) (*eks.Addon, error) {

--- a/internal/service/eks/wait.go
+++ b/internal/service/eks/wait.go
@@ -175,7 +175,7 @@ func waitFargateProfileDeleted(conn *eks.EKS, clusterName, fargateProfileName st
 
 func waitNodegroupCreated(ctx context.Context, conn *eks.EKS, clusterName, nodeGroupName string, timeout time.Duration) (*eks.Nodegroup, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{eks.NodegroupStatusPending, eks.NodegroupStatusCreating},
+		Pending: []string{eks.NodegroupStatusClaimed, eks.NodegroupStatusPending, eks.NodegroupStatusCreating},
 		Target:  []string{eks.NodegroupStatusActive},
 		Refresh: statusNodegroup(conn, clusterName, nodeGroupName),
 		Timeout: timeout,


### PR DESCRIPTION
ENHANCEMENTS:
- resource/aws_eks_cluster: Retry to create cluster when the same name or IP address is used
- resource/aws_eks_node_group: Retry to create nodegroup when the same name is used

BUG FIXES:
- resource/aws_eks_cluster: Fix `InvalidKubernetesCluster.NotFound` API error handling
- resource/aws_eks_node_group: Fix `InvalidKubernetesNodegroup.NotFound` API error handling
- resource/aws_eks_node_group: Add `CLAIMED` as pending status when creating a nodegroup
