### PR TITLE
eks: add extra services support

### DIFF
--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -170,6 +170,80 @@ func ResourceCluster() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"docker_registry_config": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"volume_iops": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										ForceNew: true,
+									},
+									"volume_size": {
+										Type:     schema.TypeInt,
+										Required: true,
+										ForceNew: true,
+									},
+									"volume_type": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringInSlice(ec2.VolumeType_Values(), false),
+									},
+								},
+							},
+						},
+						"ebs_provider_config": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"ebs_user": {
+										Type:     schema.TypeString,
+										Required: true,
+										ForceNew: true,
+									},
+								},
+							},
+						},
+						"ingress_config": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"instance_type": {
+										Type:     schema.TypeString,
+										Required: true,
+										ForceNew: true,
+									},
+									"public_ip": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
+									},
+									"volume_iops": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										ForceNew: true,
+									},
+									"volume_size": {
+										Type:     schema.TypeInt,
+										Required: true,
+										ForceNew: true,
+									},
+									"volume_type": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringInSlice(ec2.VolumeType_Values(), false),
+									},
+								},
+							},
+						},
 						"master_config": {
 							Type:     schema.TypeList,
 							Optional: true,
@@ -206,6 +280,20 @@ func ResourceCluster() *schema.Resource {
 										Required:     true,
 										ForceNew:     true,
 										ValidateFunc: validation.StringInSlice(ec2.VolumeType_Values(), false),
+									},
+								},
+							},
+						},
+						"nlb_provider_config": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"nlb_user": {
+										Type:     schema.TypeString,
+										Required: true,
+										ForceNew: true,
 									},
 								},
 							},
@@ -765,7 +853,7 @@ func expandLoggingTypes(vEnabledLogTypes *schema.Set) *eks.Logging {
 	}
 }
 
-func expandLegacyClusterParams(tfList []interface{}) *eks.LegacyClusterParams {
+func expandLegacyClusterParams(tfList []interface{}) *eks.LegacyClusterParamsRequest {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -775,13 +863,116 @@ func expandLegacyClusterParams(tfList []interface{}) *eks.LegacyClusterParams {
 		return nil
 	}
 
-	legacyParams := &eks.LegacyClusterParams{}
+	legacyParams := &eks.LegacyClusterParamsRequest{}
+
+	if dockerRegistryConfig, ok := tfMap["docker_registry_config"].([]interface{}); ok && len(dockerRegistryConfig) > 0 {
+		legacyParams.DockerRegistryConfig = expandDockerRegistryConfig(dockerRegistryConfig)
+	}
+
+	if ebsProviderConfig, ok := tfMap["ebs_provider_config"].([]interface{}); ok && len(ebsProviderConfig) > 0 {
+		legacyParams.EbsProviderConfig = expandEbsProviderConfig(ebsProviderConfig)
+	}
+
+	if ingressConfig, ok := tfMap["ingress_config"].([]interface{}); ok && len(ingressConfig) > 0 {
+		legacyParams.IngressConfig = expandIngressConfig(ingressConfig)
+	}
 
 	if masterConfig, ok := tfMap["master_config"].([]interface{}); ok && len(masterConfig) > 0 {
 		legacyParams.MasterConfig = expandMasterConfig(masterConfig)
 	}
 
+	if nlbProviderConfig, ok := tfMap["nlb_provider_config"].([]interface{}); ok && len(nlbProviderConfig) > 0 {
+		legacyParams.NlbProviderConfig = expandNlbProviderConfig(nlbProviderConfig)
+	}
+
 	return legacyParams
+}
+
+func expandDockerRegistryConfig(tfList []interface{}) *eks.DockerRegistryConfig {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]interface{})
+	if !ok || tfMap == nil {
+		return nil
+	}
+
+	dockerRegistryConfig := &eks.DockerRegistryConfig{
+		DockerRegistryRequired: aws.Bool(true),
+	}
+
+	if v, ok := tfMap["volume_iops"].(int); ok && v != 0 {
+		dockerRegistryConfig.DockerRegistryVolumeIops = aws.Int64(int64(v))
+	}
+
+	if v, ok := tfMap["volume_size"].(int); ok && v != 0 {
+		dockerRegistryConfig.DockerRegistryVolumeSize = aws.Int64(int64(v))
+	}
+
+	if v, ok := tfMap["volume_type"].(string); ok && v != "" {
+		dockerRegistryConfig.DockerRegistryVolumeType = aws.String(v)
+	}
+
+	return dockerRegistryConfig
+}
+
+func expandEbsProviderConfig(tfList []interface{}) *eks.EbsProviderConfigRequest {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]interface{})
+	if !ok || tfMap == nil {
+		return nil
+	}
+
+	ebsProviderConfig := &eks.EbsProviderConfigRequest{
+		EbsProviderRequired: aws.Bool(true),
+	}
+
+	if v, ok := tfMap["ebs_user"].(string); ok && v != "" {
+		ebsProviderConfig.EbsUser = aws.String(v)
+	}
+
+	return ebsProviderConfig
+}
+
+func expandIngressConfig(tfList []interface{}) *eks.IngressConfig {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]interface{})
+	if !ok || tfMap == nil {
+		return nil
+	}
+
+	ingressConfig := &eks.IngressConfig{
+		IngressRequired: aws.Bool(true),
+	}
+
+	if v, ok := tfMap["instance_type"].(string); ok && v != "" {
+		ingressConfig.IngressInstanceType = aws.String(v)
+	}
+
+	if v, ok := tfMap["public_ip"].(string); ok && v != "" {
+		ingressConfig.IngressPublicIp = aws.String(v)
+	}
+
+	if v, ok := tfMap["volume_iops"].(int); ok && v != 0 {
+		ingressConfig.IngressVolumeIops = aws.Int64(int64(v))
+	}
+
+	if v, ok := tfMap["volume_size"].(int); ok && v != 0 {
+		ingressConfig.IngressVolumeSize = aws.Int64(int64(v))
+	}
+
+	if v, ok := tfMap["volume_type"].(string); ok && v != "" {
+		ingressConfig.IngressVolumeType = aws.String(v)
+	}
+
+	return ingressConfig
 }
 
 func expandMasterConfig(tfList []interface{}) *eks.MasterConfig {
@@ -821,6 +1012,27 @@ func expandMasterConfig(tfList []interface{}) *eks.MasterConfig {
 	}
 
 	return masterConfig
+}
+
+func expandNlbProviderConfig(tfList []interface{}) *eks.NlbProviderConfigRequest {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]interface{})
+	if !ok || tfMap == nil {
+		return nil
+	}
+
+	nlbProviderConfig := &eks.NlbProviderConfigRequest{
+		NlbProviderRequired: aws.Bool(true),
+	}
+
+	if v, ok := tfMap["nlb_user"].(string); ok && v != "" {
+		nlbProviderConfig.NlbUser = aws.String(v)
+	}
+
+	return nlbProviderConfig
 }
 
 func flattenCertificate(certificate *eks.Certificate) []map[string]interface{} {
@@ -938,13 +1150,95 @@ func flattenNetworkConfig(apiObject *eks.KubernetesNetworkConfigResponse) []inte
 	return []interface{}{tfMap}
 }
 
-func flattenLegacyClusterParams(legacyParams *eks.LegacyClusterParams) []interface{} {
+func flattenLegacyClusterParams(legacyParams *eks.LegacyClusterParamsResponse) []interface{} {
 	if legacyParams == nil {
 		return nil
 	}
 
 	tfMap := map[string]interface{}{
-		"master_config": flattenMasterConfig(legacyParams.MasterConfig),
+		"docker_registry_config": flattenDockerRegistryConfig(legacyParams.DockerRegistryConfig),
+		"ebs_provider_config":    flattenEbsProviderConfig(legacyParams.EbsProviderConfig),
+		"ingress_config":         flattenIngressConfig(legacyParams.IngressConfig),
+		"master_config":          flattenMasterConfig(legacyParams.MasterConfig),
+		"nlb_provider_config":    flattenNlbProviderConfig(legacyParams.NlbProviderConfig),
+	}
+
+	return []interface{}{tfMap}
+}
+
+func flattenDockerRegistryConfig(dockerRegistryConfig *eks.DockerRegistryConfig) []interface{} {
+	if dockerRegistryConfig == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := dockerRegistryConfig.DockerRegistryVolumeIops; v != nil {
+		tfMap["volume_iops"] = aws.Int64Value(v)
+	}
+
+	if v := dockerRegistryConfig.DockerRegistryVolumeSize; v != nil {
+		tfMap["volume_size"] = aws.Int64Value(v)
+	}
+
+	if v := dockerRegistryConfig.DockerRegistryVolumeType; v != nil {
+		tfMap["volume_type"] = aws.StringValue(v)
+	}
+
+	if len(tfMap) == 0 {
+		return nil
+	}
+
+	return []interface{}{tfMap}
+}
+
+func flattenEbsProviderConfig(ebsProviderConfig *eks.EbsProviderConfigResponse) []interface{} {
+	if ebsProviderConfig == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := ebsProviderConfig.EbsUserName; v != nil {
+		tfMap["ebs_user"] = aws.StringValue(v)
+	}
+
+	if len(tfMap) == 0 {
+		return nil
+	}
+
+	return []interface{}{tfMap}
+}
+
+func flattenIngressConfig(ingressConfig *eks.IngressConfig) []interface{} {
+	if ingressConfig == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := ingressConfig.IngressInstanceType; v != nil {
+		tfMap["instance_type"] = aws.StringValue(v)
+	}
+
+	if v := ingressConfig.IngressPublicIp; v != nil {
+		tfMap["public_ip"] = aws.StringValue(v)
+	}
+
+	if v := ingressConfig.IngressVolumeIops; v != nil {
+		tfMap["volume_iops"] = aws.Int64Value(v)
+	}
+
+	if v := ingressConfig.IngressVolumeSize; v != nil {
+		tfMap["volume_size"] = aws.Int64Value(v)
+	}
+
+	if v := ingressConfig.IngressVolumeType; v != nil {
+		tfMap["volume_type"] = aws.StringValue(v)
+	}
+
+	if len(tfMap) == 0 {
+		return nil
 	}
 
 	return []interface{}{tfMap}
@@ -962,6 +1256,24 @@ func flattenMasterConfig(masterConfig *eks.MasterConfig) []interface{} {
 		"volume_iops":       aws.Int64Value(masterConfig.MastersVolumeIops),
 		"volume_size":       aws.Int64Value(masterConfig.MastersVolumeSize),
 		"volume_type":       aws.StringValue(masterConfig.MastersVolumeType),
+	}
+
+	return []interface{}{tfMap}
+}
+
+func flattenNlbProviderConfig(nlbProviderConfig *eks.NlbProviderConfigResponse) []interface{} {
+	if nlbProviderConfig == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := nlbProviderConfig.NlbUserName; v != nil {
+		tfMap["nlb_user"] = aws.StringValue(v)
+	}
+
+	if len(tfMap) == 0 {
+		return nil
 	}
 
 	return []interface{}{tfMap}

--- a/internal/service/eks/cluster_data_source.go
+++ b/internal/service/eks/cluster_data_source.go
@@ -85,6 +85,67 @@ func DataSourceCluster() *schema.Resource {
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"docker_registry_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"volume_iops": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"volume_size": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"volume_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"ebs_provider_config": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"ebs_user": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"ingress_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"instance_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"public_ip": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"volume_iops": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"volume_size": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"volume_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
 						"master_config": {
 							Type:     schema.TypeList,
 							Computed: true,
@@ -111,6 +172,18 @@ func DataSourceCluster() *schema.Resource {
 										Computed: true,
 									},
 									"volume_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"nlb_provider_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"nlb_user": {
 										Type:     schema.TypeString,
 										Computed: true,
 									},

--- a/website/docs/d/eks_cluster.md
+++ b/website/docs/d/eks_cluster.md
@@ -36,8 +36,7 @@ In addition to all arguments above, the following attributes are exported:
 * `kubernetes_network_config` - The Kubernetes network configuration.
   The structure of this block is [described below](#kubernetes_network_config).
 * `legacy_cluster_params` - The parameters for fine-tuning the Kubernetes cluster.
-    * `master_config` - The configuration of the master node of the cluster.
-        The structure of this block is [described below](#master_config).
+  The structure of this block is [described below](#legacy_cluster_params).
 * `platform_version` - The platform version for the cluster.
 * `status` - The status of the EKS cluster. One of `CLAIMED`, `CREATING`, `DELETED`, `DELETING`, `ERROR`, `MODIFYING`, `PENDING`, `PROVISIONING`, `READY`, `REPAIRING`.
 * `version` - The Kubernetes server version for the cluster.
@@ -52,16 +51,64 @@ The `kubernetes_network_config` block has the following structure:
 * `ip_family` - The IP family used to assign Kubernetes pod and service addresses.
 * `service_ipv4_cidr` - The CIDR block to assign Kubernetes service IP addresses from.
 
-#### master_config
+#### legacy_cluster_params
+
+The `legacy_cluster_params` block has the following structure:
+
+* `docker_registry_config` – The configuration of the Docker Registry.
+  The structure of this block is [described below](#docker_registry_config).
+* `ebs_provider_config` – The configuration of the EBS Provider.
+  The structure of this block is [described below](#ebs_provider_config).
+* `ingress_config` – The configuration of the Ingress controller.
+  The structure of this block is [described below](#ingress_config).
+* `master_config` – The configuration of the master node of the cluster.
+  The structure of this block is [described below](#master_config).
+* `nlb_provider_config` – The configuration of the NLB Provider.
+  The structure of this block is [described below](#nlb_provider_config).
+
+##### docker_registry_config
+
+The `docker_registry_config` block has the following structure:
+
+* `volume_iops` - The number of read/write operations per second for the Docker Registry volume.
+* `volume_size` - The size of the Docker Registry volume in GiB.
+* `volume_type` - The type of the Docker Registry volume.
+    * _Valid values:_ `st2`, `gp2`, `io2`
+
+##### ebs_provider_config
+
+The `ebs_provider_config` block has the following structure:
+
+* `ebs_user` - The EBS Provider user name.
+
+##### ingress_config
+
+The `ingress_config` block has the following structure:
+
+* `instance_type` - The instance type of the Ingress controller.
+* `public_ip` - The public IP address at which the Ingress controller can be accessed.
+* `volume_iops` - The number of read/write operations per second for the Ingress controller volume.
+* `volume_size` - The size of the Ingress controller volume in GiB.
+* `volume_type` - The type of the Ingress controller volume.
+    * _Valid values:_ `st2`, `gp2`, `io2`
+
+##### master_config
 
 The `master_config` block has the following structure:
 
-* `high_availability` - Indicates whether this is a high-availability cluster.
+* `high_availability` - Indicates whether to deploy a high-availability cluster.
 * `instance_type` - The instance type of the master node.
-* `public_ip` - The public IP address at which the master node is accessed.
+* `public_ip` - The public IP address at which the master node can be accessed.
 * `volume_iops` - The number of read/write operations per second for the master node volume.
 * `volume_size` - The size of the master node volume in GiB.
 * `volume_type` - The type of the master node volume.
+    * _Valid values:_ `st2`, `gp2`, `io2`
+
+##### nlb_provider_config
+
+The `nlb_provider_config` block has the following structure:
+
+* `nlb_user` - The NLB Provider user name.
 
 #### vpc_config
 

--- a/website/docs/r/eks_cluster.md
+++ b/website/docs/r/eks_cluster.md
@@ -76,13 +76,58 @@ resource "aws_eks_cluster" "example" {
 }
 ```
 
+### EKS Cluster with extra services
+
+~> **Note**
+This example uses the same VPC and subnet as in the [EKS High-Availability Cluster example](#eks-high-availability-cluster).
+
+```terraform
+resource "aws_eks_cluster" "example" {
+  name    = "tf-cluster-extra-services"
+  version = "1.30.2"
+
+  legacy_cluster_params {
+    docker_registry_config {
+      volume_type = "gp2"
+      volume_size = 32
+    }
+
+    ebs_provider_config {
+      ebs_user = "ebs"
+    }
+
+    ingress_config {
+      instance_type = "c5.large"
+      volume_type   = "gp2"
+      volume_size   = 32
+    }
+
+    master_config {
+      high_availability = false
+      instance_type     = "c5.large"
+      volume_type       = "gp2"
+      volume_size       = 64
+    }
+
+    nlb_provider_config {
+      nlb_user = "nlb"
+    }
+  }
+
+  vpc_config {
+    subnet_ids = [aws_subnet.example.id]
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:
 
 * `name` - (Required) The name of the cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]+$`).
 * `version` - (Required) The Kubernetes server version for the cluster.
-* `vpc_config` - (Required) Configuration block for the VPC associated with your cluster. Detailed below. Also contains attributes detailed in the Attributes section.
+* `vpc_config` - (Required) Configuration block for the VPC associated with your cluster.
+  The structure of this block is [described below](#vpc_config).
 
 The following arguments are optional:
 
@@ -90,11 +135,6 @@ The following arguments are optional:
 * `legacy_cluster_params` - (Optional) The parameters for fine-tuning the Kubernetes cluster.
   The structure of this block is [described below](#legacy_cluster_params).
 * `tags` - (Optional) Map of tags to assign to the cluster. If a provider [`default_tags` configuration block][default-tags] is used, tags with matching keys will overwrite those defined at the provider level.
-
-### vpc_config Arguments
-
-* `security_group_ids` - (Optional) List of security group IDs.
-* `subnet_ids` - (Required) List of subnet IDs.
 
 ### kubernetes_network_config
 
@@ -112,8 +152,44 @@ The block must meet the following requirements:
 
 The `legacy_cluster_params` block has the following structure:
 
+* `docker_registry_config` – (Optional) The configuration of the Docker Registry.
+  The structure of this block is [described below](#docker_registry_config).
+* `ebs_provider_config` – (Optional) The configuration of the EBS Provider.
+  The structure of this block is [described below](#ebs_provider_config).
+* `ingress_config` – (Optional) The configuration of the Ingress controller.
+  The structure of this block is [described below](#ingress_config).
 * `master_config` - (Optional) The configuration of the master node of the cluster.
   The structure of this block is [described below](#master_config).
+* `nlb_provider_config` – (Optional) The configuration of the NLB Provider.
+  The structure of this block is [described below](#nlb_provider_config).
+
+#### docker_registry_config
+
+The `docker_registry_config` block has the following structure:
+
+* `volume_size` - (Required) The size of the Docker Registry volume in GiB.
+* `volume_type` - (Required) The type of the Docker Registry volume.
+    * _Valid values:_ `st2`, `gp2`, `io2`
+* `volume_iops` - (Optional) The number of read/write operations per second for the Docker Registry volume.
+    * _Constraints_: Required only when `volume_type` is `io2`
+
+#### ebs_provider_config
+
+The `ebs_provider_config` block has the following structure:
+
+* `ebs_user` - (Required) The EBS Provider user name.
+
+#### ingress_config
+
+The `ingress_config` block has the following structure:
+
+* `instance_type` - (Required) The instance type of the Ingress controller.
+* `volume_size` - (Required) The size of the Ingress controller volume in GiB.
+* `volume_type` - (Required) The type of the Ingress controller volume.
+    * _Valid values:_ `st2`, `gp2`, `io2`
+* `public_ip` - (Optional) The public IP address at which the Ingress controller can be accessed.
+* `volume_iops` - (Optional) The number of read/write operations per second for the Ingress controller volume.
+    * _Constraints_: Required only when `volume_type` is `io2`
 
 #### master_config
 
@@ -121,12 +197,23 @@ The `master_config` block has the following structure:
 
 * `high_availability` - (Required) Indicates whether to deploy a high-availability cluster.
 * `instance_type` - (Required) The instance type of the master node.
-* `public_ip` - (Optional) The public IP address at which the master node can be accessed.
-* `volume_iops` - (Optional) The number of read/write operations per second for the master node volume.
-  The parameter must be set if `volume_type` is `io2`.
 * `volume_size` - (Required) The size of the master node volume in GiB.
 * `volume_type` - (Required) The type of the master node volume.
     * _Valid values:_ `st2`, `gp2`, `io2`
+* `public_ip` - (Optional) The public IP address at which the master node can be accessed.
+* `volume_iops` - (Optional) The number of read/write operations per second for the master node volume.
+    * _Constraints_: Required only when `volume_type` is `io2`
+
+#### nlb_provider_config
+
+The `nlb_provider_config` block has the following structure:
+
+* `nlb_user` - (Required) The NLB Provider user name.
+
+### vpc_config
+
+* `subnet_ids` - (Required) List of subnet IDs.
+* `security_group_ids` - (Optional) List of security group IDs.
 
 ## Attribute Reference
 


### PR DESCRIPTION
ENHANCEMENTS:

- resource/aws_eks_cluster, data-source/aws_eks_cluster: add new `docker_registry_config`, `ebs_provider_config`, `ingress_config`,  `nlb_provider_config` blocks to the `legacy_cluster_params` block.