### PR TITLE
K2 Cloud regional endpoints

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -554,15 +554,15 @@ func AccountID() string {
 }
 
 func Region() string {
-	return conns.GetEnvVarWithDefault(conns.EnvVarDefaultRegion, endpoints.UsWest2RegionID)
+	return conns.GetEnvVarWithDefault(conns.EnvVarDefaultRegion, endpoints.RuMskRegionID)
 }
 
 func AlternateRegion() string {
-	return conns.GetEnvVarWithDefault(conns.EnvVarAlternateRegion, endpoints.UsEast1RegionID)
+	return conns.GetEnvVarWithDefault(conns.EnvVarAlternateRegion, endpoints.RuSpbRegionID)
 }
 
 func ThirdRegion() string {
-	return conns.GetEnvVarWithDefault(conns.EnvVarThirdRegion, endpoints.UsEast2RegionID)
+	return conns.GetEnvVarWithDefault(conns.EnvVarThirdRegion, endpoints.RuSpbRegionID)
 }
 
 func Partition() string {
@@ -805,7 +805,7 @@ func PreCheckIAMServiceLinkedRole(t *testing.T, pathPrefix string) {
 }
 
 func ConfigAlternateAccountProvider() string {
-	//lintignore:AT004
+	// lintignore:AT004
 	return fmt.Sprintf(`
 provider "awsalternate" {
   access_key = %[1]q
@@ -833,7 +833,7 @@ func ConfigMultipleRegionProvider(regions int) string {
 }
 
 func ConfigDefaultAndIgnoreTagsKeyPrefixes1(key1, value1, keyPrefix1 string) string {
-	//lintignore:AT004
+	// lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
   default_tags {
@@ -849,7 +849,7 @@ provider "aws" {
 }
 
 func ConfigDefaultAndIgnoreTagsKeys1(key1, value1 string) string {
-	//lintignore:AT004
+	// lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
   default_tags {
@@ -865,7 +865,7 @@ provider "aws" {
 }
 
 func ConfigIgnoreTagsKeyPrefixes1(keyPrefix1 string) string {
-	//lintignore:AT004
+	// lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
   ignore_tags {
@@ -876,7 +876,7 @@ provider "aws" {
 }
 
 func ConfigIgnoreTagsKeys(key1 string) string {
-	//lintignore:AT004
+	// lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
   ignore_tags {
@@ -890,7 +890,7 @@ provider "aws" {
 //
 // This can be used to build multiple provider configuration testing.
 func ConfigNamedRegionalProvider(providerName string, region string) string {
-	//lintignore:AT004
+	// lintignore:AT004
 	return fmt.Sprintf(`
 provider %[1]q {
   region = %[2]q
@@ -903,7 +903,7 @@ provider %[1]q {
 // This can only be used for single provider configuration testing as it
 // overwrites the "aws" provider configuration.
 func ConfigRegionalProvider(region string) string {
-	//lintignore:AT004
+	// lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
   region = %[1]q
@@ -1034,7 +1034,7 @@ func RegisterServiceErrorCheckFunc(endpointID string, f ServiceErrorCheckFunc) {
 
 	if _, ok := serviceErrorCheckFuncs[endpointID]; ok {
 		// already registered
-		panic(fmt.Sprintf("Cannot re-register a service! ServiceErrorCheckFunc exists for %s", endpointID)) //lintignore:R009
+		panic(fmt.Sprintf("Cannot re-register a service! ServiceErrorCheckFunc exists for %s", endpointID)) // lintignore:R009
 	}
 
 	serviceErrorCheckFuncs[endpointID] = f
@@ -1129,7 +1129,7 @@ func PreCheckSkipError(err error) bool {
 }
 
 func ConfigDefaultTags_Tags0() string {
-	//lintignore:AT004
+	// lintignore:AT004
 	return ConfigCompose(
 		testAccProviderConfigBase,
 		`
@@ -1143,7 +1143,7 @@ provider "aws" {
 }
 
 func ConfigDefaultTags_Tags1(tag1, value1 string) string {
-	//lintignore:AT004
+	// lintignore:AT004
 	return ConfigCompose(
 		testAccProviderConfigBase,
 		fmt.Sprintf(`
@@ -1163,7 +1163,7 @@ provider "aws" {
 }
 
 func ConfigDefaultTags_Tags2(tag1, value1, tag2, value2 string) string {
-	//lintignore:AT004
+	// lintignore:AT004
 	return ConfigCompose(
 		testAccProviderConfigBase,
 		fmt.Sprintf(`
@@ -1188,7 +1188,7 @@ func PreCheckAssumeRoleARN(t *testing.T) {
 }
 
 func ConfigAssumeRolePolicy(policy string) string {
-	//lintignore:AT004
+	// lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
   assume_role {
@@ -1206,7 +1206,7 @@ provider "aws" {
 }
 
 data "aws_caller_identity" "current" {}
-` //lintignore:AT004
+` // lintignore:AT004
 
 const testAccProviderConfigBase = `
 data "aws_partition" "provider_test" {}

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -1537,13 +1537,6 @@ func CheckACMPCACertificateAuthorityExists(n string, certificateAuthority *acmpc
 	}
 }
 
-// PreCheckAPIGatewayTypeEDGE checks if endpoint config type EDGE can be used in a test and skips test if not (i.e., not in standard partition).
-func PreCheckAPIGatewayTypeEDGE(t *testing.T) {
-	if Partition() != endpoints.AwsPartitionID {
-		t.Skipf("skipping test; Endpoint Configuration type EDGE is not supported in this partition (%s)", Partition())
-	}
-}
-
 func PreCheckDirectoryService(t *testing.T) {
 	conn := Provider.Meta().(*conns.AWSClient).DSConn
 

--- a/internal/acctest/ec2_classic.go
+++ b/internal/acctest/ec2_classic.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -71,10 +70,6 @@ func EC2ClassicRegion() string {
 
 	if v != "" {
 		return v
-	}
-
-	if Partition() == endpoints.AwsPartitionID {
-		return endpoints.UsEast1RegionID
 	}
 
 	return Region()

--- a/internal/acctest/provider_test.go
+++ b/internal/acctest/provider_test.go
@@ -196,6 +196,8 @@ func TestAccProvider_endpoints(t *testing.T) {
 }
 
 func TestAccProvider_fipsEndpoint(t *testing.T) {
+	Skip(t, "FIPS isn't supported.")
+
 	rName := sdkacctest.RandomWithPrefix(ResourcePrefix)
 	resourceName := "aws_s3_bucket.test"
 
@@ -372,7 +374,7 @@ func TestAccProvider_IgnoreTagsKeys_multiple(t *testing.T) {
 	})
 }
 
-func TestAccProvider_Region_awsC2S(t *testing.T) {
+func TestAccProvider_Region_K2RuMsk(t *testing.T) {
 	var providers []*schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -382,101 +384,14 @@ func TestAccProvider_Region_awsC2S(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRegionConfig(endpoints.UsIsoEast1RegionID),
+				Config: testAccRegionConfig(endpoints.RuMskRegionID),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDNSSuffix(&providers, "c2s.ic.gov"),
-					testAccCheckPartition(&providers, endpoints.AwsIsoPartitionID),
-					testAccCheckReverseDNSPrefix(&providers, "gov.ic.c2s"),
+					testAccCheckDNSSuffix(&[]*schema.Provider{Provider}, "k2.cloud"),
+					// "c2" is hardcoded as a partition in conns.Config.Client(..).
+					testAccCheckPartition(&providers, "c2"),
+					testAccCheckRegion(&providers, endpoints.RuMskRegionID),
+					testAccCheckReverseDNSPrefix(&providers, "cloud.k2"),
 				),
-				PlanOnly: true,
-			},
-		},
-	})
-}
-
-func TestAccProvider_Region_awsChina(t *testing.T) {
-	var providers []*schema.Provider
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { PreCheck(t) },
-		ErrorCheck:        ErrorCheck(t),
-		ProviderFactories: FactoriesInternal(&providers),
-		CheckDestroy:      nil,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRegionConfig(endpoints.CnNorthwest1RegionID),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDNSSuffix(&providers, "amazonaws.com.cn"),
-					testAccCheckPartition(&providers, endpoints.AwsCnPartitionID),
-					testAccCheckReverseDNSPrefix(&providers, "cn.com.amazonaws"),
-				),
-				PlanOnly: true,
-			},
-		},
-	})
-}
-
-func TestAccProvider_Region_awsCommercial(t *testing.T) {
-	var providers []*schema.Provider
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { PreCheck(t) },
-		ErrorCheck:        ErrorCheck(t),
-		ProviderFactories: FactoriesInternal(&providers),
-		CheckDestroy:      nil,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRegionConfig(endpoints.UsWest2RegionID),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDNSSuffix(&providers, "amazonaws.com"),
-					testAccCheckPartition(&providers, endpoints.AwsPartitionID),
-					testAccCheckReverseDNSPrefix(&providers, "com.amazonaws"),
-				),
-				PlanOnly: true,
-			},
-		},
-	})
-}
-
-func TestAccProvider_Region_awsGovCloudUs(t *testing.T) {
-	var providers []*schema.Provider
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { PreCheck(t) },
-		ErrorCheck:        ErrorCheck(t),
-		ProviderFactories: FactoriesInternal(&providers),
-		CheckDestroy:      nil,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRegionConfig(endpoints.UsGovWest1RegionID),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDNSSuffix(&providers, "amazonaws.com"),
-					testAccCheckPartition(&providers, endpoints.AwsUsGovPartitionID),
-					testAccCheckReverseDNSPrefix(&providers, "com.amazonaws"),
-				),
-				PlanOnly: true,
-			},
-		},
-	})
-}
-
-func TestAccProvider_Region_awsSC2S(t *testing.T) {
-	var providers []*schema.Provider
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { PreCheck(t) },
-		ErrorCheck:        ErrorCheck(t),
-		ProviderFactories: FactoriesInternal(&providers),
-		CheckDestroy:      nil,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRegionConfig(endpoints.UsIsobEast1RegionID),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDNSSuffix(&providers, "sc2s.sgov.gov"),
-					testAccCheckPartition(&providers, endpoints.AwsIsoBPartitionID),
-					testAccCheckReverseDNSPrefix(&providers, "gov.sgov.sc2s"),
-				),
-				PlanOnly: true,
 			},
 		},
 	})
@@ -492,18 +407,19 @@ func TestAccProvider_Region_stsRegion(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSTSRegionConfig(endpoints.UsEast1RegionID, endpoints.UsWest2RegionID),
+				Config: testAccSTSRegionConfig(endpoints.RuMskRegionID, endpoints.RuSpbRegionID),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRegion(&providers, endpoints.UsEast1RegionID),
-					testAccCheckSTSRegion(&providers, endpoints.UsWest2RegionID),
+					testAccCheckRegion(&providers, endpoints.RuMskRegionID),
+					testAccCheckSTSRegion(&providers, endpoints.RuSpbRegionID),
 				),
-				PlanOnly: true,
 			},
 		},
 	})
 }
 
 func TestAccProvider_AssumeRole_empty(t *testing.T) {
+	Skip(t, "Data source sts.aws_caller_identity isn't supported.")
+
 	var providers []*schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -945,7 +861,7 @@ func testAccCheckUnusualEndpoints(providers *[]*schema.Provider, unusual1, unusu
 }
 
 func testAccEndpointsConfig(endpoints string) string {
-	//lintignore:AT004
+	// lintignore:AT004
 	return ConfigCompose(
 		testAccProviderConfigBase,
 		fmt.Sprintf(`
@@ -963,7 +879,7 @@ provider "aws" {
 }
 
 func testAccFIPSEndpointConfig(endpoint, rName string) string {
-	//lintignore:AT004
+	// lintignore:AT004
 	return ConfigCompose(
 		testAccProviderConfigBase,
 		fmt.Sprintf(`
@@ -986,7 +902,7 @@ resource "aws_s3_bucket_acl" "test" {
 }
 
 func testAccUnusualEndpointsConfig(unusual1, unusual2, unusual3 []string) string {
-	//lintignore:AT004
+	// lintignore:AT004
 	return ConfigCompose(
 		testAccProviderConfigBase,
 		fmt.Sprintf(`
@@ -1006,7 +922,7 @@ provider "aws" {
 }
 
 func testAccIgnoreTagsKeys0Config() string {
-	//lintignore:AT004
+	// lintignore:AT004
 	return ConfigCompose(
 		testAccProviderConfigBase,
 		`
@@ -1020,7 +936,7 @@ provider "aws" {
 }
 
 func testAccIgnoreTagsKeys1Config(tag1 string) string {
-	//lintignore:AT004
+	// lintignore:AT004
 	return ConfigCompose(
 		testAccProviderConfigBase,
 		fmt.Sprintf(`
@@ -1038,7 +954,7 @@ provider "aws" {
 }
 
 func testAccIgnoreTagsKeys2Config(tag1, tag2 string) string {
-	//lintignore:AT004
+	// lintignore:AT004
 	return ConfigCompose(
 		testAccProviderConfigBase,
 		fmt.Sprintf(`
@@ -1056,7 +972,7 @@ provider "aws" {
 }
 
 func testAccIgnoreTagsKeyPrefixes0Config() string {
-	//lintignore:AT004
+	// lintignore:AT004
 	return ConfigCompose(
 		testAccProviderConfigBase,
 		`
@@ -1070,7 +986,7 @@ provider "aws" {
 }
 
 func testAccIgnoreTagsKeyPrefixes3Config(tagPrefix1 string) string {
-	//lintignore:AT004
+	// lintignore:AT004
 	return ConfigCompose(
 		testAccProviderConfigBase,
 		fmt.Sprintf(`
@@ -1088,7 +1004,7 @@ provider "aws" {
 }
 
 func testAccIgnoreTagsKeyPrefixes2Config(tagPrefix1, tagPrefix2 string) string {
-	//lintignore:AT004
+	// lintignore:AT004
 	return ConfigCompose(
 		testAccProviderConfigBase,
 		fmt.Sprintf(`
@@ -1106,7 +1022,7 @@ provider "aws" {
 }
 
 func testAccDefaultTagsEmptyConfigurationBlockConfig() string {
-	//lintignore:AT004
+	// lintignore:AT004
 	return ConfigCompose(
 		testAccProviderConfigBase,
 		`
@@ -1122,7 +1038,7 @@ provider "aws" {
 }
 
 func testAccDefaultAndIgnoreTagsEmptyConfigurationBlockConfig() string {
-	//lintignore:AT004
+	// lintignore:AT004
 	return ConfigCompose(
 		testAccProviderConfigBase,
 		`
@@ -1139,7 +1055,7 @@ provider "aws" {
 }
 
 func testAccIgnoreTagsEmptyConfigurationBlockConfig() string {
-	//lintignore:AT004
+	// lintignore:AT004
 	return ConfigCompose(
 		testAccProviderConfigBase,
 		`
@@ -1155,7 +1071,7 @@ provider "aws" {
 }
 
 func testAccRegionConfig(region string) string {
-	//lintignore:AT004
+	// lintignore:AT004
 	return ConfigCompose(
 		testAccProviderConfigBase,
 		fmt.Sprintf(`
@@ -1170,7 +1086,7 @@ provider "aws" {
 }
 
 func testAccSTSRegionConfig(region, stsRegion string) string {
-	//lintignore:AT004
+	// lintignore:AT004
 	return ConfigCompose(
 		testAccProviderConfigBase,
 		fmt.Sprintf(`

--- a/internal/conns/config.go
+++ b/internal/conns/config.go
@@ -268,25 +268,6 @@ func (c *Config) Client(ctx context.Context) (interface{}, diag.Diagnostics) {
 	s3Config.DisableRestProtocolURICleaning = aws.Bool(true)
 	client.S3ConnURICleaningDisabled = s3.New(sess.Copy(s3Config))
 
-	// Force "global" services to correct regions
-	switch partition {
-	case endpoints.AwsPartitionID:
-		globalAcceleratorConfig.Region = aws.String(endpoints.UsWest2RegionID)
-		route53Config.Region = aws.String(endpoints.UsEast1RegionID)
-		route53RecoveryControlConfigConfig.Region = aws.String(endpoints.UsWest2RegionID)
-		route53RecoveryReadinessConfig.Region = aws.String(endpoints.UsWest2RegionID)
-		shieldConfig.Region = aws.String(endpoints.UsEast1RegionID)
-	case endpoints.AwsCnPartitionID:
-		// The AWS Go SDK is missing endpoint information for Route 53 in the AWS China partition.
-		// This can likely be removed in the future.
-		if aws.StringValue(route53Config.Endpoint) == "" {
-			route53Config.Endpoint = aws.String("https://api.route53.cn")
-		}
-		route53Config.Region = aws.String(endpoints.CnNorthwest1RegionID)
-	case endpoints.AwsUsGovPartitionID:
-		route53Config.Region = aws.String(endpoints.UsGovWest1RegionID)
-	}
-
 	client.GlobalAcceleratorConn = globalaccelerator.New(sess.Copy(globalAcceleratorConfig))
 	client.Route53Conn = route53.New(sess.Copy(route53Config))
 	client.Route53RecoveryControlConfigConn = route53recoverycontrolconfig.New(sess.Copy(route53RecoveryControlConfigConfig))

--- a/internal/conns/config.go
+++ b/internal/conns/config.go
@@ -226,9 +226,6 @@ func (c *Config) Client(ctx context.Context) (interface{}, diag.Diagnostics) {
 	client.Route53DomainsConn = route53domains.NewFromConfig(cfg, func(o *route53domains.Options) {
 		if endpoint := c.Endpoints[names.Route53Domains]; endpoint != "" {
 			o.EndpointResolver = route53domains.EndpointResolverFromURL(endpoint)
-		} else if partition == endpoints.AwsPartitionID {
-			// Route 53 Domains is only available in AWS Commercial us-east-1 Region.
-			o.Region = endpoints.UsEast1RegionID
 		}
 	})
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/service/eks"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/elbv2"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/iam"
+	"github.com/hashicorp/terraform-provider-aws/internal/service/meta"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/paas"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/route53"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/s3"
@@ -584,11 +585,11 @@ func Provider() *schema.Provider {
 			//
 			// "aws_location_map": location.DataSourceMap(),
 			//
-			// "aws_arn":                     meta.DataSourceARN(),
+			"aws_arn": meta.DataSourceARN(),
 			// "aws_billing_service_account": meta.DataSourceBillingServiceAccount(),
 			// "aws_default_tags":            meta.DataSourceDefaultTags(),
 			// "aws_ip_ranges":               meta.DataSourceIPRanges(),
-			// "aws_partition":               meta.DataSourcePartition(),
+			"aws_partition": meta.DataSourcePartition(),
 			// "aws_region":                  meta.DataSourceRegion(),
 			// "aws_regions":                 meta.DataSourceRegions(),
 			// "aws_service":                 meta.DataSourceService(),

--- a/internal/service/apigateway/acc_test.go
+++ b/internal/service/apigateway/acc_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/apigateway"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -74,20 +73,10 @@ func testAccEdgeDomainNameRegionProviderConfig() string {
 	return acctest.ConfigRegionalProvider(testAccGetEdgeDomainNameRegion())
 }
 
+// FIXME: testAccEdgeDomainNameRegion is always "". Fix it, if API Gateway Domain Name is supported.
+
 // testAccEdgeDomainNameRegion returns the API Gateway Domain Name region for testing
 func testAccGetEdgeDomainNameRegion() string {
-	if testAccEdgeDomainNameRegion != "" {
-		return testAccEdgeDomainNameRegion
-	}
-
-	// AWS Commercial: https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html
-	// AWS GovCloud (US) - edge custom domain names not supported: https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-abp.html
-	// AWS China - edge custom domain names not supported: https://docs.amazonaws.cn/en_us/aws/latest/userguide/api-gateway.html
-	switch acctest.Partition() {
-	case endpoints.AwsPartitionID:
-		testAccEdgeDomainNameRegion = endpoints.UsEast1RegionID
-	}
-
 	return testAccEdgeDomainNameRegion
 }
 

--- a/internal/service/apigateway/authorizer_test.go
+++ b/internal/service/apigateway/authorizer_test.go
@@ -25,7 +25,7 @@ func TestAccAPIGatewayAuthorizer_basic(t *testing.T) {
 	roleResourceName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckAuthorizerDestroy,
@@ -72,7 +72,7 @@ func TestAccAPIGatewayAuthorizer_cognito(t *testing.T) {
 	resourceName := "aws_api_gateway_authorizer.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckAuthorizerDestroy,
@@ -110,7 +110,7 @@ func TestAccAPIGatewayAuthorizer_Cognito_authorizerCredentials(t *testing.T) {
 	iamRoleResourceName := "aws_iam_role.lambda"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckAuthorizerDestroy,
@@ -141,7 +141,7 @@ func TestAccAPIGatewayAuthorizer_switchAuthType(t *testing.T) {
 	roleResourceName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckAuthorizerDestroy,
@@ -188,7 +188,7 @@ func TestAccAPIGatewayAuthorizer_switchAuthorizerTTL(t *testing.T) {
 	resourceName := "aws_api_gateway_authorizer.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckAuthorizerDestroy,
@@ -235,7 +235,7 @@ func TestAccAPIGatewayAuthorizer_authTypeValidation(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckAuthorizerDestroy,
@@ -262,7 +262,7 @@ func TestAccAPIGatewayAuthorizer_Zero_ttl(t *testing.T) {
 	resourceName := "aws_api_gateway_authorizer.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckAuthorizerDestroy,
@@ -290,7 +290,7 @@ func TestAccAPIGatewayAuthorizer_disappears(t *testing.T) {
 	resourceName := "aws_api_gateway_authorizer.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckAuthorizerDestroy,

--- a/internal/service/apigateway/deployment_test.go
+++ b/internal/service/apigateway/deployment_test.go
@@ -23,7 +23,7 @@ func TestAccAPIGatewayDeployment_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix("tf-acc-test-deployment")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDeploymentDestroy,
@@ -54,7 +54,7 @@ func TestAccAPIGatewayDeployment_Disappears_restAPI(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix("tf-acc-test-deployment")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDeploymentDestroy,
@@ -78,7 +78,7 @@ func TestAccAPIGatewayDeployment_triggers(t *testing.T) {
 	resourceName := "aws_api_gateway_deployment.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDeploymentDestroy,
@@ -134,7 +134,7 @@ func TestAccAPIGatewayDeployment_description(t *testing.T) {
 	resourceName := "aws_api_gateway_deployment.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDeploymentDestroy,
@@ -163,7 +163,7 @@ func TestAccAPIGatewayDeployment_stageDescription(t *testing.T) {
 	resourceName := "aws_api_gateway_deployment.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDeploymentDestroy,
@@ -186,7 +186,7 @@ func TestAccAPIGatewayDeployment_stageName(t *testing.T) {
 	resourceName := "aws_api_gateway_deployment.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDeploymentDestroy,
@@ -214,7 +214,7 @@ func TestAccAPIGatewayDeployment_StageName_emptyString(t *testing.T) {
 	resourceName := "aws_api_gateway_deployment.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDeploymentDestroy,
@@ -235,7 +235,7 @@ func TestAccAPIGatewayDeployment_variables(t *testing.T) {
 	resourceName := "aws_api_gateway_deployment.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDeploymentDestroy,

--- a/internal/service/apigateway/documentation_part_test.go
+++ b/internal/service/apigateway/documentation_part_test.go
@@ -27,7 +27,7 @@ func TestAccAPIGatewayDocumentationPart_basic(t *testing.T) {
 	resourceName := "aws_api_gateway_documentation_part.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDocumentationPartDestroy,
@@ -72,7 +72,7 @@ func TestAccAPIGatewayDocumentationPart_method(t *testing.T) {
 	resourceName := "aws_api_gateway_documentation_part.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDocumentationPartDestroy,
@@ -121,7 +121,7 @@ func TestAccAPIGatewayDocumentationPart_responseHeader(t *testing.T) {
 	resourceName := "aws_api_gateway_documentation_part.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDocumentationPartDestroy,
@@ -173,7 +173,7 @@ func TestAccAPIGatewayDocumentationPart_disappears(t *testing.T) {
 	resourceName := "aws_api_gateway_documentation_part.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDocumentationPartDestroy,

--- a/internal/service/apigateway/documentation_version_test.go
+++ b/internal/service/apigateway/documentation_version_test.go
@@ -25,7 +25,7 @@ func TestAccAPIGatewayDocumentationVersion_basic(t *testing.T) {
 	resourceName := "aws_api_gateway_documentation_version.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDocumentationVersionDestroy,
@@ -60,7 +60,7 @@ func TestAccAPIGatewayDocumentationVersion_allFields(t *testing.T) {
 	resourceName := "aws_api_gateway_documentation_version.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDocumentationVersionDestroy,
@@ -102,7 +102,7 @@ func TestAccAPIGatewayDocumentationVersion_disappears(t *testing.T) {
 	resourceName := "aws_api_gateway_documentation_version.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDocumentationVersionDestroy,

--- a/internal/service/apigateway/gateway_response_test.go
+++ b/internal/service/apigateway/gateway_response_test.go
@@ -22,7 +22,7 @@ func TestAccAPIGatewayGatewayResponse_basic(t *testing.T) {
 	resourceName := "aws_api_gateway_gateway_response.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckGatewayResponseDestroy,
@@ -65,7 +65,7 @@ func TestAccAPIGatewayGatewayResponse_disappears(t *testing.T) {
 	resourceName := "aws_api_gateway_gateway_response.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckGatewayResponseDestroy,

--- a/internal/service/apigateway/integration_response_test.go
+++ b/internal/service/apigateway/integration_response_test.go
@@ -21,7 +21,7 @@ func TestAccAPIGatewayIntegrationResponse_basic(t *testing.T) {
 	resourceName := "aws_api_gateway_integration_response.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckIntegrationResponseDestroy,
@@ -69,7 +69,7 @@ func TestAccAPIGatewayIntegrationResponse_disappears(t *testing.T) {
 	resourceName := "aws_api_gateway_integration_response.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckIntegrationResponseDestroy,

--- a/internal/service/apigateway/integration_test.go
+++ b/internal/service/apigateway/integration_test.go
@@ -22,7 +22,7 @@ func TestAccAPIGatewayIntegration_basic(t *testing.T) {
 	resourceName := "aws_api_gateway_integration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckIntegrationDestroy,
@@ -138,7 +138,7 @@ func TestAccAPIGatewayIntegration_contentHandling(t *testing.T) {
 	resourceName := "aws_api_gateway_integration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckIntegrationDestroy,
@@ -214,7 +214,7 @@ func TestAccAPIGatewayIntegration_CacheKey_parameters(t *testing.T) {
 	resourceName := "aws_api_gateway_integration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckIntegrationDestroy,
@@ -257,7 +257,7 @@ func TestAccAPIGatewayIntegration_integrationType(t *testing.T) {
 	resourceName := "aws_api_gateway_integration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckIntegrationDestroy,
@@ -302,7 +302,7 @@ func TestAccAPIGatewayIntegration_TLS_insecureSkipVerification(t *testing.T) {
 	resourceName := "aws_api_gateway_integration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckIntegrationDestroy,
@@ -339,7 +339,7 @@ func TestAccAPIGatewayIntegration_disappears(t *testing.T) {
 	resourceName := "aws_api_gateway_integration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckIntegrationDestroy,

--- a/internal/service/apigateway/method_response_test.go
+++ b/internal/service/apigateway/method_response_test.go
@@ -21,7 +21,7 @@ func TestAccAPIGatewayMethodResponse_basic(t *testing.T) {
 	resourceName := "aws_api_gateway_method_response.error"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckMethodResponseDestroy,
@@ -65,7 +65,7 @@ func TestAccAPIGatewayMethodResponse_disappears(t *testing.T) {
 	resourceName := "aws_api_gateway_method_response.error"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckMethodResponseDestroy,

--- a/internal/service/apigateway/method_settings_test.go
+++ b/internal/service/apigateway/method_settings_test.go
@@ -21,7 +21,7 @@ func TestAccAPIGatewayMethodSettings_basic(t *testing.T) {
 	resourceName := "aws_api_gateway_method_settings.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckMethodSettingsDestroy,
@@ -50,7 +50,7 @@ func TestAccAPIGatewayMethodSettings_Settings_cacheDataEncrypted(t *testing.T) {
 	resourceName := "aws_api_gateway_method_settings.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckMethodSettingsDestroy,
@@ -87,7 +87,7 @@ func TestAccAPIGatewayMethodSettings_Settings_cacheTTLInSeconds(t *testing.T) {
 	resourceName := "aws_api_gateway_method_settings.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckMethodSettingsDestroy,
@@ -132,7 +132,7 @@ func TestAccAPIGatewayMethodSettings_Settings_cachingEnabled(t *testing.T) {
 	resourceName := "aws_api_gateway_method_settings.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckMethodSettingsDestroy,
@@ -169,7 +169,7 @@ func TestAccAPIGatewayMethodSettings_Settings_dataTraceEnabled(t *testing.T) {
 	resourceName := "aws_api_gateway_method_settings.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckMethodSettingsDestroy,
@@ -206,7 +206,7 @@ func TestAccAPIGatewayMethodSettings_Settings_loggingLevel(t *testing.T) {
 	resourceName := "aws_api_gateway_method_settings.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckMethodSettingsDestroy,
@@ -245,7 +245,7 @@ func TestAccAPIGatewayMethodSettings_Settings_metricsEnabled(t *testing.T) {
 	resourceName := "aws_api_gateway_method_settings.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckMethodSettingsDestroy,
@@ -284,7 +284,7 @@ func TestAccAPIGatewayMethodSettings_Settings_multiple(t *testing.T) {
 	resourceName := "aws_api_gateway_method_settings.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckMethodSettingsDestroy,
@@ -327,7 +327,7 @@ func TestAccAPIGatewayMethodSettings_Settings_requireAuthorizationForCacheContro
 	resourceName := "aws_api_gateway_method_settings.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckMethodSettingsDestroy,
@@ -364,7 +364,7 @@ func TestAccAPIGatewayMethodSettings_Settings_throttlingBurstLimit(t *testing.T)
 	resourceName := "aws_api_gateway_method_settings.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckMethodSettingsDestroy,
@@ -402,7 +402,7 @@ func TestAccAPIGatewayMethodSettings_Settings_throttlingBurstLimitDisabledByDefa
 	resourceName := "aws_api_gateway_method_settings.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckMethodSettingsDestroy,
@@ -439,7 +439,7 @@ func TestAccAPIGatewayMethodSettings_Settings_throttlingRateLimit(t *testing.T) 
 	resourceName := "aws_api_gateway_method_settings.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckMethodSettingsDestroy,
@@ -477,7 +477,7 @@ func TestAccAPIGatewayMethodSettings_Settings_throttlingRateLimitDisabledByDefau
 	resourceName := "aws_api_gateway_method_settings.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckMethodSettingsDestroy,
@@ -514,7 +514,7 @@ func TestAccAPIGatewayMethodSettings_Settings_unauthorizedCacheControlHeaderStra
 	resourceName := "aws_api_gateway_method_settings.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckMethodSettingsDestroy,
@@ -584,7 +584,7 @@ func TestAccAPIGatewayMethodSettings_disappears(t *testing.T) {
 	resourceName := "aws_api_gateway_method_settings.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckMethodSettingsDestroy,

--- a/internal/service/apigateway/method_test.go
+++ b/internal/service/apigateway/method_test.go
@@ -22,7 +22,7 @@ func TestAccAPIGatewayMethod_basic(t *testing.T) {
 	resourceName := "aws_api_gateway_method.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckMethodDestroy,
@@ -61,7 +61,7 @@ func TestAccAPIGatewayMethod_customAuthorizer(t *testing.T) {
 	resourceName := "aws_api_gateway_method.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckMethodDestroy,
@@ -103,7 +103,7 @@ func TestAccAPIGatewayMethod_cognitoAuthorizer(t *testing.T) {
 	resourceName := "aws_api_gateway_method.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckMethodDestroy,
@@ -148,7 +148,7 @@ func TestAccAPIGatewayMethod_customRequestValidator(t *testing.T) {
 	resourceName := "aws_api_gateway_method.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckMethodDestroy,
@@ -189,7 +189,7 @@ func TestAccAPIGatewayMethod_disappears(t *testing.T) {
 	resourceName := "aws_api_gateway_method.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckMethodDestroy,
@@ -212,7 +212,7 @@ func TestAccAPIGatewayMethod_operationName(t *testing.T) {
 	resourceName := "aws_api_gateway_method.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckMethodDestroy,

--- a/internal/service/apigateway/model_test.go
+++ b/internal/service/apigateway/model_test.go
@@ -23,7 +23,7 @@ func TestAccAPIGatewayModel_basic(t *testing.T) {
 	resourceName := "aws_api_gateway_model.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckModelDestroy,
@@ -59,7 +59,7 @@ func TestAccAPIGatewayModel_disappears(t *testing.T) {
 	resourceName := "aws_api_gateway_model.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckModelDestroy,

--- a/internal/service/apigateway/request_validator_test.go
+++ b/internal/service/apigateway/request_validator_test.go
@@ -21,7 +21,7 @@ func TestAccAPIGatewayRequestValidator_basic(t *testing.T) {
 	resourceName := "aws_api_gateway_request_validator.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRequestValidatorDestroy,
@@ -66,7 +66,7 @@ func TestAccAPIGatewayRequestValidator_disappears(t *testing.T) {
 	resourceName := "aws_api_gateway_request_validator.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRequestValidatorDestroy,

--- a/internal/service/apigateway/resource_data_source_test.go
+++ b/internal/service/apigateway/resource_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccAPIGatewayResourceDataSource_basic(t *testing.T) {
 	dataSourceName2 := "data.aws_api_gateway_resource.example_v1_endpoint"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/service/apigateway/resource_test.go
+++ b/internal/service/apigateway/resource_test.go
@@ -21,7 +21,7 @@ func TestAccAPIGatewayResource_basic(t *testing.T) {
 	resourceName := "aws_api_gateway_resource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckResourceDestroy,
@@ -53,7 +53,7 @@ func TestAccAPIGatewayResource_update(t *testing.T) {
 	resourceName := "aws_api_gateway_resource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckResourceDestroy,
@@ -97,7 +97,7 @@ func TestAccAPIGatewayResource_disappears(t *testing.T) {
 	resourceName := "aws_api_gateway_resource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckResourceDestroy,

--- a/internal/service/apigateway/rest_api_data_source_test.go
+++ b/internal/service/apigateway/rest_api_data_source_test.go
@@ -14,7 +14,7 @@ func TestAccAPIGatewayRestAPIDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_api_gateway_rest_api.test"
 	resourceName := "aws_api_gateway_rest_api.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/service/apigateway/rest_api_policy_test.go
+++ b/internal/service/apigateway/rest_api_policy_test.go
@@ -23,7 +23,7 @@ func TestAccAPIGatewayRestAPIPolicy_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRestAPIPolicyDestroy,
@@ -57,7 +57,7 @@ func TestAccAPIGatewayRestAPIPolicy_disappears(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRestAPIPolicyDestroy,
@@ -80,7 +80,7 @@ func TestAccAPIGatewayRestAPIPolicy_Disappears_restAPI(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRestAPIPolicyDestroy,

--- a/internal/service/apigateway/rest_api_test.go
+++ b/internal/service/apigateway/rest_api_test.go
@@ -22,7 +22,7 @@ func TestAccAPIGatewayRestAPI_basic(t *testing.T) {
 	resourceName := "aws_api_gateway_rest_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRestAPIDestroy,
@@ -62,7 +62,7 @@ func TestAccAPIGatewayRestAPI_tags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRestAPIDestroy,
@@ -112,7 +112,7 @@ func TestAccAPIGatewayRestAPI_disappears(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRestAPIDestroy,
@@ -264,7 +264,7 @@ func TestAccAPIGatewayRestAPI_apiKeySource(t *testing.T) {
 	resourceName := "aws_api_gateway_rest_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRestAPIDestroy,
@@ -302,7 +302,7 @@ func TestAccAPIGatewayRestAPI_APIKeySource_overrideBody(t *testing.T) {
 	resourceName := "aws_api_gateway_rest_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRestAPIDestroy,
@@ -346,7 +346,7 @@ func TestAccAPIGatewayRestAPI_APIKeySource_setByBody(t *testing.T) {
 	resourceName := "aws_api_gateway_rest_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRestAPIDestroy,
@@ -374,7 +374,7 @@ func TestAccAPIGatewayRestAPI_binaryMediaTypes(t *testing.T) {
 	resourceName := "aws_api_gateway_rest_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRestAPIDestroy,
@@ -411,7 +411,7 @@ func TestAccAPIGatewayRestAPI_BinaryMediaTypes_overrideBody(t *testing.T) {
 	resourceName := "aws_api_gateway_rest_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRestAPIDestroy,
@@ -458,7 +458,7 @@ func TestAccAPIGatewayRestAPI_BinaryMediaTypes_setByBody(t *testing.T) {
 	resourceName := "aws_api_gateway_rest_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRestAPIDestroy,
@@ -487,7 +487,7 @@ func TestAccAPIGatewayRestAPI_body(t *testing.T) {
 	resourceName := "aws_api_gateway_rest_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRestAPIDestroy,
@@ -531,7 +531,7 @@ func TestAccAPIGatewayRestAPI_description(t *testing.T) {
 	resourceName := "aws_api_gateway_rest_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRestAPIDestroy,
@@ -566,7 +566,7 @@ func TestAccAPIGatewayRestAPI_Description_overrideBody(t *testing.T) {
 	resourceName := "aws_api_gateway_rest_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRestAPIDestroy,
@@ -610,7 +610,7 @@ func TestAccAPIGatewayRestAPI_Description_setByBody(t *testing.T) {
 	resourceName := "aws_api_gateway_rest_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRestAPIDestroy,
@@ -637,7 +637,7 @@ func TestAccAPIGatewayRestAPI_disableExecuteAPIEndpoint(t *testing.T) {
 	resourceName := "aws_api_gateway_rest_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRestAPIDestroy,
@@ -675,7 +675,7 @@ func TestAccAPIGatewayRestAPI_DisableExecuteAPIEndpoint_overrideBody(t *testing.
 	resourceName := "aws_api_gateway_rest_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRestAPIDestroy,
@@ -719,7 +719,7 @@ func TestAccAPIGatewayRestAPI_DisableExecuteAPIEndpoint_setByBody(t *testing.T) 
 	resourceName := "aws_api_gateway_rest_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRestAPIDestroy,
@@ -888,7 +888,7 @@ func TestAccAPIGatewayRestAPI_minimumCompressionSize(t *testing.T) {
 	resourceName := "aws_api_gateway_rest_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRestAPIDestroy,
@@ -930,7 +930,7 @@ func TestAccAPIGatewayRestAPI_MinimumCompressionSize_overrideBody(t *testing.T) 
 	resourceName := "aws_api_gateway_rest_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRestAPIDestroy,
@@ -974,7 +974,7 @@ func TestAccAPIGatewayRestAPI_MinimumCompressionSize_setByBody(t *testing.T) {
 	resourceName := "aws_api_gateway_rest_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRestAPIDestroy,
@@ -1005,7 +1005,7 @@ func TestAccAPIGatewayRestAPI_Name_overrideBody(t *testing.T) {
 	resourceName := "aws_api_gateway_rest_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRestAPIDestroy,
@@ -1049,7 +1049,7 @@ func TestAccAPIGatewayRestAPI_parameters(t *testing.T) {
 	resourceName := "aws_api_gateway_rest_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRestAPIDestroy,
@@ -1085,7 +1085,7 @@ func TestAccAPIGatewayRestAPI_Policy_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRestAPIDestroy,
@@ -1118,7 +1118,7 @@ func TestAccAPIGatewayRestAPI_Policy_order(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRestAPIDestroy,
@@ -1143,7 +1143,7 @@ func TestAccAPIGatewayRestAPI_Policy_overrideBody(t *testing.T) {
 	resourceName := "aws_api_gateway_rest_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRestAPIDestroy,
@@ -1190,7 +1190,7 @@ func TestAccAPIGatewayRestAPI_Policy_setByBody(t *testing.T) {
 	resourceName := "aws_api_gateway_rest_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckRestAPIDestroy,

--- a/internal/service/apigateway/stage_test.go
+++ b/internal/service/apigateway/stage_test.go
@@ -21,7 +21,7 @@ func TestAccAPIGatewayStage_basic(t *testing.T) {
 	resourceName := "aws_api_gateway_stage.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckStageDestroy,
@@ -87,7 +87,7 @@ func TestAccAPIGatewayStage_cache(t *testing.T) {
 	resourceName := "aws_api_gateway_stage.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckStageDestroy,
@@ -140,7 +140,7 @@ func TestAccAPIGatewayStage_cache_size_cache_disabled(t *testing.T) {
 	resourceName := "aws_api_gateway_stage.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckStageDestroy,
@@ -185,7 +185,7 @@ func TestAccAPIGatewayStage_Disappears_referencingDeployment(t *testing.T) {
 	resourceName := "aws_api_gateway_stage.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckStageDestroy,
@@ -212,7 +212,7 @@ func TestAccAPIGatewayStage_tags(t *testing.T) {
 	resourceName := "aws_api_gateway_stage.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckStageDestroy,
@@ -258,7 +258,7 @@ func TestAccAPIGatewayStage_disappears(t *testing.T) {
 	resourceName := "aws_api_gateway_stage.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckStageDestroy,
@@ -282,7 +282,7 @@ func TestAccAPIGatewayStage_disappears_restApi(t *testing.T) {
 	resourceName := "aws_api_gateway_stage.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckStageDestroy,
@@ -311,7 +311,7 @@ func TestAccAPIGatewayStage_accessLogSettings(t *testing.T) {
 	csv := `$context.identity.sourceIp,$context.identity.caller,$context.identity.user,$context.requestTime,$context.httpMethod,$context.resourcePath,$context.protocol,$context.status,$context.responseLength,$context.requestId`
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckStageDestroy,
@@ -380,7 +380,7 @@ func TestAccAPIGatewayStage_AccessLogSettings_kinesis(t *testing.T) {
 	csv := `$context.identity.sourceIp,$context.identity.caller,$context.identity.user,$context.requestTime,$context.httpMethod,$context.resourcePath,$context.protocol,$context.status,$context.responseLength,$context.requestId`
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckStageDestroy,
@@ -443,7 +443,7 @@ func TestAccAPIGatewayStage_waf(t *testing.T) {
 	resourceName := "aws_api_gateway_stage.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckStageDestroy,
@@ -477,7 +477,7 @@ func TestAccAPIGatewayStage_canarySettings(t *testing.T) {
 	resourceName := "aws_api_gateway_stage.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckStageDestroy,

--- a/internal/service/apigateway/usage_plan_key_test.go
+++ b/internal/service/apigateway/usage_plan_key_test.go
@@ -24,7 +24,7 @@ func TestAccAPIGatewayUsagePlanKey_basic(t *testing.T) {
 	resourceName := "aws_api_gateway_usage_plan_key.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckUsagePlanKeyDestroy,
@@ -56,7 +56,7 @@ func TestAccAPIGatewayUsagePlanKey_disappears(t *testing.T) {
 	resourceName := "aws_api_gateway_usage_plan_key.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckUsagePlanKeyDestroy,
@@ -78,7 +78,7 @@ func TestAccAPIGatewayUsagePlanKey_KeyID_concurrency(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckUsagePlanKeyDestroy,

--- a/internal/service/apigateway/usage_plan_test.go
+++ b/internal/service/apigateway/usage_plan_test.go
@@ -23,7 +23,7 @@ func TestAccAPIGatewayUsagePlan_basic(t *testing.T) {
 	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckUsagePlanDestroy,
@@ -63,7 +63,7 @@ func TestAccAPIGatewayUsagePlan_tags(t *testing.T) {
 	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckUsagePlanDestroy,
@@ -110,7 +110,7 @@ func TestAccAPIGatewayUsagePlan_description(t *testing.T) {
 	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckUsagePlanDestroy,
@@ -164,7 +164,7 @@ func TestAccAPIGatewayUsagePlan_productCode(t *testing.T) {
 	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckUsagePlanDestroy,
@@ -212,7 +212,7 @@ func TestAccAPIGatewayUsagePlan_throttling(t *testing.T) {
 	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckUsagePlanDestroy,
@@ -267,7 +267,7 @@ func TestAccAPIGatewayUsagePlan_throttlingInitialRateLimit(t *testing.T) {
 	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckUsagePlanDestroy,
@@ -294,7 +294,7 @@ func TestAccAPIGatewayUsagePlan_quota(t *testing.T) {
 	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckUsagePlanDestroy,
@@ -350,7 +350,7 @@ func TestAccAPIGatewayUsagePlan_apiStages(t *testing.T) {
 	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckUsagePlanDestroy,
@@ -434,7 +434,7 @@ func TestAccAPIGatewayUsagePlan_APIStages_multiple(t *testing.T) {
 	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckUsagePlanDestroy,
@@ -467,7 +467,7 @@ func TestAccAPIGatewayUsagePlan_APIStages_throttle(t *testing.T) {
 	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckUsagePlanDestroy,
@@ -525,7 +525,7 @@ func TestAccAPIGatewayUsagePlan_disappears(t *testing.T) {
 	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, apigateway.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckUsagePlanDestroy,

--- a/internal/service/cloudfront/cloudfront_test.go
+++ b/internal/service/cloudfront/cloudfront_test.go
@@ -1,7 +1,6 @@
 package cloudfront_test
 
 import (
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
@@ -11,10 +10,6 @@ import (
 // are necessary and overwrites the "aws" provider configuration.
 func testAccCloudfrontRegionProviderConfig() string {
 	switch acctest.Partition() {
-	case endpoints.AwsPartitionID:
-		return acctest.ConfigRegionalProvider(endpoints.UsEast1RegionID)
-	case endpoints.AwsCnPartitionID:
-		return acctest.ConfigRegionalProvider(endpoints.CnNorthwest1RegionID)
 	default:
 		return acctest.ConfigRegionalProvider(acctest.Region())
 	}

--- a/internal/service/cloudfront/distribution.go
+++ b/internal/service/cloudfront/distribution.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -910,14 +909,7 @@ func resourceDistributionRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("in_progress_validation_batches", resp.Distribution.InProgressInvalidationBatches)
 	d.Set("etag", resp.ETag)
 	d.Set("arn", resp.Distribution.ARN)
-
-	// override hosted_zone_id from flattenDistributionConfig
-	region := meta.(*conns.AWSClient).Region
-	if v, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), region); ok && v.ID() == endpoints.AwsCnPartitionID {
-		d.Set("hosted_zone_id", cloudFrontCNRoute53ZoneID)
-	} else {
-		d.Set("hosted_zone_id", cloudFrontRoute53ZoneID)
-	}
+	d.Set("hosted_zone_id", cloudFrontRoute53ZoneID)
 
 	tags, err := ListTags(conn, d.Get("arn").(string))
 	if err != nil {

--- a/internal/service/cloudfront/distribution_configuration_structure.go
+++ b/internal/service/cloudfront/distribution_configuration_structure.go
@@ -24,11 +24,6 @@ import (
 // is used to set the zone_id attribute.
 const cloudFrontRoute53ZoneID = "Z2FDTNDATAQYW2"
 
-// cloudFrontCNRoute53ZoneID defines the route 53 zone ID for CloudFront in AWS CN.
-// This is used to set the zone_id attribute.
-// ref: https://docs.amazonaws.cn/en_us/aws/latest/userguide/route53.html
-const cloudFrontCNRoute53ZoneID = "Z3RFFRIM2A3IF5"
-
 // Assemble the *cloudfront.DistributionConfig variable. Calls out to various
 // expander functions to convert attributes and sub-attributes to the various
 // complex structures which are necessary to properly build the

--- a/internal/service/cloudfront/distribution_data_source.go
+++ b/internal/service/cloudfront/distribution_data_source.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -86,12 +85,8 @@ func dataSourceDistributionRead(d *schema.ResourceData, meta interface{}) error 
 		d.Set("in_progress_validation_batches", distribution.InProgressInvalidationBatches)
 		d.Set("last_modified_time", aws.String(distribution.LastModifiedTime.String()))
 		d.Set("status", distribution.Status)
-		region := meta.(*conns.AWSClient).Region
-		if v, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), region); ok && v.ID() == endpoints.AwsCnPartitionID {
-			d.Set("hosted_zone_id", cloudFrontCNRoute53ZoneID)
-		} else {
-			d.Set("hosted_zone_id", cloudFrontRoute53ZoneID)
-		}
+		d.Set("hosted_zone_id", cloudFrontRoute53ZoneID)
+
 		if distributionConfig := distribution.DistributionConfig; distributionConfig != nil {
 			d.Set("enabled", distributionConfig.Enabled)
 			if aliases := distributionConfig.Aliases; aliases != nil {

--- a/internal/service/cloudfront/log_delivery_canonical_user_id_data_source.go
+++ b/internal/service/cloudfront/log_delivery_canonical_user_id_data_source.go
@@ -1,17 +1,14 @@
 package cloudfront
 
 import (
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
+
+// FIXME: this resource probably can be removed.
 
 const (
 	// See https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html#AccessLogsBucketAndFileOwnership.
 	defaultCloudFrontLogDeliveryCanonicalUserId = "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0"
-
-	// See https://docs.amazonaws.cn/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html#AccessLogsBucketAndFileOwnership.
-	cnCloudFrontLogDeliveryCanonicalUserId = "a52cb28745c0c06e84ec548334e44bfa7fc2a85c54af20cd59e4969344b7af56"
 )
 
 func DataSourceLogDeliveryCanonicalUserID() *schema.Resource {
@@ -28,18 +25,7 @@ func DataSourceLogDeliveryCanonicalUserID() *schema.Resource {
 }
 
 func dataSourceLogDeliveryCanonicalUserIDRead(d *schema.ResourceData, meta interface{}) error {
-	canonicalId := defaultCloudFrontLogDeliveryCanonicalUserId
-
-	region := meta.(*conns.AWSClient).Region
-	if v, ok := d.GetOk("region"); ok {
-		region = v.(string)
-	}
-
-	if v, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), region); ok && v.ID() == endpoints.AwsCnPartitionID {
-		canonicalId = cnCloudFrontLogDeliveryCanonicalUserId
-	}
-
-	d.SetId(canonicalId)
+	d.SetId(defaultCloudFrontLogDeliveryCanonicalUserId)
 
 	return nil
 }

--- a/internal/service/cloudfront/log_delivery_canonical_user_id_data_source_test.go
+++ b/internal/service/cloudfront/log_delivery_canonical_user_id_data_source_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -22,42 +21,6 @@ func TestAccCloudFrontLogDeliveryCanonicalUserIDDataSource_basic(t *testing.T) {
 				Config: testAccLogDeliveryCanonicalUserIdDataSourceConfig(""),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "id", "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccCloudFrontLogDeliveryCanonicalUserIDDataSource_default(t *testing.T) {
-	dataSourceName := "data.aws_cloudfront_log_delivery_canonical_user_id.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(cloudfront.EndpointsID, t) },
-		ErrorCheck:        acctest.ErrorCheck(t, cloudfront.EndpointsID),
-		ProviderFactories: acctest.ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccLogDeliveryCanonicalUserIdDataSourceConfig(endpoints.UsWest2RegionID),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "id", "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccCloudFrontLogDeliveryCanonicalUserIDDataSource_cn(t *testing.T) {
-	dataSourceName := "data.aws_cloudfront_log_delivery_canonical_user_id.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(cloudfront.EndpointsID, t) },
-		ErrorCheck:        acctest.ErrorCheck(t, cloudfront.EndpointsID),
-		ProviderFactories: acctest.ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccLogDeliveryCanonicalUserIdDataSourceConfig(endpoints.CnNorthwest1RegionID),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "id", "a52cb28745c0c06e84ec548334e44bfa7fc2a85c54af20cd59e4969344b7af56"),
 				),
 			},
 		},

--- a/internal/service/cloudtrail/service_account_data_source.go
+++ b/internal/service/cloudtrail/service_account_data_source.go
@@ -4,42 +4,16 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
+// FIXME: get rid of `ServiceAccountPerRegionMap` and probably of this resource.
+
 // See http://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-supported-regions.html
 // See https://docs.aws.amazon.com/govcloud-us/latest/ug-east/verifying-cloudtrail.html
 // See https://docs.aws.amazon.com/govcloud-us/latest/ug-west/verifying-cloudtrail.html
-var ServiceAccountPerRegionMap = map[string]string{
-	endpoints.AfSouth1RegionID:     "525921808201",
-	endpoints.ApEast1RegionID:      "119688915426",
-	endpoints.ApNortheast1RegionID: "216624486486",
-	endpoints.ApNortheast2RegionID: "492519147666",
-	endpoints.ApNortheast3RegionID: "765225791966",
-	endpoints.ApSouth1RegionID:     "977081816279",
-	endpoints.ApSoutheast1RegionID: "903692715234",
-	endpoints.ApSoutheast2RegionID: "284668455005",
-	endpoints.ApSoutheast3RegionID: "069019280451",
-	endpoints.CaCentral1RegionID:   "819402241893",
-	endpoints.CnNorth1RegionID:     "193415116832",
-	endpoints.CnNorthwest1RegionID: "681348832753",
-	endpoints.EuCentral1RegionID:   "035351147821",
-	endpoints.EuNorth1RegionID:     "829690693026",
-	endpoints.EuSouth1RegionID:     "669305197877",
-	endpoints.EuWest1RegionID:      "859597730677",
-	endpoints.EuWest2RegionID:      "282025262664",
-	endpoints.EuWest3RegionID:      "262312530599",
-	endpoints.MeSouth1RegionID:     "034638983726",
-	endpoints.SaEast1RegionID:      "814480443879",
-	endpoints.UsEast1RegionID:      "086441151436",
-	endpoints.UsEast2RegionID:      "475085895292",
-	endpoints.UsGovEast1RegionID:   "608710470296",
-	endpoints.UsGovWest1RegionID:   "608710470296",
-	endpoints.UsWest1RegionID:      "388731089494",
-	endpoints.UsWest2RegionID:      "113285607260",
-}
+var ServiceAccountPerRegionMap = map[string]string{}
 
 func DataSourceServiceAccount() *schema.Resource {
 	return &schema.Resource{

--- a/internal/service/cognitoidp/acc_test.go
+++ b/internal/service/cognitoidp/acc_test.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -71,19 +70,10 @@ func testAccUserPoolCustomDomainRegionProviderConfig() string {
 	return acctest.ConfigRegionalProvider(testAccGetUserPoolCustomDomainRegion())
 }
 
+// FIXME: testAccCognitoUserPoolCustomDomainRegion is always "".
+//  Fix it, if Cognito User Pool Custom Domains are supported.
+
 // testAccGetUserPoolCustomDomainRegion returns the Cognito User Pool Custom Domains region for testing
 func testAccGetUserPoolCustomDomainRegion() string {
-	if testAccCognitoUserPoolCustomDomainRegion != "" {
-		return testAccCognitoUserPoolCustomDomainRegion
-	}
-
-	// AWS Commercial: https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-add-custom-domain.html
-	// AWS GovCloud (US) - not supported: https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-cog.html
-	// AWS China - not supported: https://docs.amazonaws.cn/en_us/aws/latest/userguide/cognito.html
-	switch acctest.Partition() {
-	case endpoints.AwsPartitionID:
-		testAccCognitoUserPoolCustomDomainRegion = endpoints.UsEast1RegionID
-	}
-
 	return testAccCognitoUserPoolCustomDomainRegion
 }

--- a/internal/service/devicefarm/device_pool_test.go
+++ b/internal/service/devicefarm/device_pool_test.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/devicefarm"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -26,9 +25,6 @@ func TestAccDeviceFarmDevicePool_basic(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
-			// Currently, DeviceFarm is only supported in us-west-2
-			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
-			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, devicefarm.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
@@ -71,9 +67,6 @@ func TestAccDeviceFarmDevicePool_tags(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
-			// Currently, DeviceFarm is only supported in us-west-2
-			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
-			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, devicefarm.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
@@ -122,9 +115,6 @@ func TestAccDeviceFarmDevicePool_disappears(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
-			// Currently, DeviceFarm is only supported in us-west-2
-			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
-			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, devicefarm.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
@@ -152,9 +142,6 @@ func TestAccDeviceFarmDevicePool_disappears_project(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
-			// Currently, DeviceFarm is only supported in us-west-2
-			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
-			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, devicefarm.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,

--- a/internal/service/devicefarm/instance_profile_test.go
+++ b/internal/service/devicefarm/instance_profile_test.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/devicefarm"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -26,9 +25,6 @@ func TestAccDeviceFarmInstanceProfile_basic(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
-			// Currently, DeviceFarm is only supported in us-west-2
-			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
-			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, devicefarm.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
@@ -72,9 +68,6 @@ func TestAccDeviceFarmInstanceProfile_tags(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
-			// Currently, DeviceFarm is only supported in us-west-2
-			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
-			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, devicefarm.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
@@ -123,9 +116,6 @@ func TestAccDeviceFarmInstanceProfile_disappears(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
-			// Currently, DeviceFarm is only supported in us-west-2
-			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
-			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, devicefarm.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,

--- a/internal/service/devicefarm/network_profile_test.go
+++ b/internal/service/devicefarm/network_profile_test.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/devicefarm"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -26,9 +25,6 @@ func TestAccDeviceFarmNetworkProfile_basic(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
-			// Currently, DeviceFarm is only supported in us-west-2
-			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
-			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, devicefarm.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
@@ -78,9 +74,6 @@ func TestAccDeviceFarmNetworkProfile_tags(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
-			// Currently, DeviceFarm is only supported in us-west-2
-			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
-			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, devicefarm.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
@@ -129,9 +122,6 @@ func TestAccDeviceFarmNetworkProfile_disappears(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
-			// Currently, DeviceFarm is only supported in us-west-2
-			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
-			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, devicefarm.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
@@ -159,9 +149,6 @@ func TestAccDeviceFarmNetworkProfile_disappears_project(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
-			// Currently, DeviceFarm is only supported in us-west-2
-			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
-			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, devicefarm.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,

--- a/internal/service/devicefarm/project_test.go
+++ b/internal/service/devicefarm/project_test.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/devicefarm"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -26,9 +25,6 @@ func TestAccDeviceFarmProject_basic(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
-			// Currently, DeviceFarm is only supported in us-west-2
-			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
-			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, devicefarm.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
@@ -69,9 +65,6 @@ func TestAccDeviceFarmProject_timeout(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
-			// Currently, DeviceFarm is only supported in us-west-2
-			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
-			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, devicefarm.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
@@ -111,9 +104,6 @@ func TestAccDeviceFarmProject_tags(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
-			// Currently, DeviceFarm is only supported in us-west-2
-			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
-			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, devicefarm.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
@@ -162,9 +152,6 @@ func TestAccDeviceFarmProject_disappears(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
-			// Currently, DeviceFarm is only supported in us-west-2
-			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
-			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, devicefarm.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,

--- a/internal/service/devicefarm/test_grid_project_test.go
+++ b/internal/service/devicefarm/test_grid_project_test.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/devicefarm"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -26,9 +25,6 @@ func TestAccDeviceFarmTestGridProject_basic(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
-			// Currently, DeviceFarm is only supported in us-west-2
-			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
-			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, devicefarm.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
@@ -70,9 +66,6 @@ func TestAccDeviceFarmTestGridProject_vpc(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
-			// Currently, DeviceFarm is only supported in us-west-2
-			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
-			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, devicefarm.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
@@ -105,9 +98,6 @@ func TestAccDeviceFarmTestGridProject_tags(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
-			// Currently, DeviceFarm is only supported in us-west-2
-			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
-			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, devicefarm.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
@@ -156,9 +146,6 @@ func TestAccDeviceFarmTestGridProject_disappears(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
-			// Currently, DeviceFarm is only supported in us-west-2
-			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
-			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, devicefarm.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,

--- a/internal/service/devicefarm/upload_test.go
+++ b/internal/service/devicefarm/upload_test.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/devicefarm"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -26,9 +25,6 @@ func TestAccDeviceFarmUpload_basic(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
-			// Currently, DeviceFarm is only supported in us-west-2
-			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
-			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, devicefarm.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
@@ -75,9 +71,6 @@ func TestAccDeviceFarmUpload_disappears(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
-			// Currently, DeviceFarm is only supported in us-west-2
-			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
-			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, devicefarm.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
@@ -105,9 +98,6 @@ func TestAccDeviceFarmUpload_disappears_project(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
-			// Currently, DeviceFarm is only supported in us-west-2
-			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
-			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, devicefarm.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,

--- a/internal/service/dynamodb/global_table_test.go
+++ b/internal/service/dynamodb/global_table_test.go
@@ -3,11 +3,9 @@ package dynamodb_test
 import (
 	"fmt"
 	"regexp"
-	"sort"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -26,7 +24,6 @@ func TestAccDynamoDBGlobalTable_basic(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			testAccPreCheckGlobalTable(t)
-			testAccGlobalTablePreCheck(t)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, dynamodb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
@@ -72,7 +69,6 @@ func TestAccDynamoDBGlobalTable_multipleRegions(t *testing.T) {
 			acctest.PreCheck(t)
 			testAccPreCheckGlobalTable(t)
 			acctest.PreCheckMultipleRegion(t, 2)
-			testAccGlobalTablePreCheck(t)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, dynamodb.EndpointsID),
 		ProviderFactories: acctest.FactoriesAlternate(&providers),
@@ -161,28 +157,6 @@ func testAccPreCheckGlobalTable(t *testing.T) {
 
 	if err != nil {
 		t.Fatalf("unexpected PreCheck error: %s", err)
-	}
-}
-
-// testAccGlobalTablePreCheck checks if aws_dynamodb_global_table (version 2017.11.29) can be used and skips test if not.
-// Region availability for Version 2017.11.29: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GlobalTables.html
-func testAccGlobalTablePreCheck(t *testing.T) {
-	supportRegionsSort := []string{
-		endpoints.ApNortheast1RegionID,
-		endpoints.ApNortheast2RegionID,
-		endpoints.ApSoutheast1RegionID,
-		endpoints.ApSoutheast2RegionID,
-		endpoints.EuCentral1RegionID,
-		endpoints.EuWest1RegionID,
-		endpoints.EuWest2RegionID,
-		endpoints.UsEast1RegionID,
-		endpoints.UsEast2RegionID,
-		endpoints.UsWest1RegionID,
-		endpoints.UsWest2RegionID,
-	}
-
-	if acctest.Region() != supportRegionsSort[sort.SearchStrings(supportRegionsSort, acctest.Region())] {
-		t.Skipf("skipping test; aws_dynamodb_global_table (DynamoDB v2017.11.29) not supported in region %s", acctest.Region())
 	}
 }
 

--- a/internal/service/ec2/ec2_availability_zone_group_test.go
+++ b/internal/service/ec2/ec2_availability_zone_group_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -19,7 +18,7 @@ func TestAccEC2AvailabilityZoneGroup_optInStatus(t *testing.T) {
 	localZone := "us-west-2-lax-1" // lintignore:AWSAT003
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckRegion(t, endpoints.UsWest2RegionID) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      nil,

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -1372,7 +1371,7 @@ func TestAccEC2Instance_BlockDeviceTags_withAttachedVolume(t *testing.T) {
 				),
 			},
 			{
-				//https://github.com/hashicorp/terraform-provider-aws/issues/17074
+				// https://github.com/hashicorp/terraform-provider-aws/issues/17074
 				Config: testAccInstanceConfigBlockDeviceTagsAttachedVolumeWithTags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
@@ -1733,7 +1732,7 @@ func TestAccEC2Instance_rootBlockDeviceMismatch(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckRegion(t, endpoints.UsWest2RegionID) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckInstanceDestroy,
@@ -6480,7 +6479,7 @@ resource "aws_instance" "test" {
     Name = %[1]q
   }
 }
-`, rName)) //lintignore:AWSAT002
+`, rName)) // lintignore:AWSAT002
 }
 
 func testAccInstanceConfigForceNewAndTagsDrift(rName string) string {

--- a/internal/service/ec2/vpc_default_subnet_test.go
+++ b/internal/service/ec2/vpc_default_subnet_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -80,7 +79,6 @@ func testAccDefaultSubnet_Existing_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
-			acctest.PreCheckRegionNot(t, endpoints.UsWest2RegionID, endpoints.UsGovWest1RegionID)
 			testAccPreCheckDefaultSubnetExists(t)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, ec2.EndpointsID),
@@ -124,7 +122,6 @@ func testAccDefaultSubnet_Existing_forceDestroy(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
-			acctest.PreCheckRegionNot(t, endpoints.UsWest2RegionID, endpoints.UsGovWest1RegionID)
 			testAccPreCheckDefaultSubnetExists(t)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, ec2.EndpointsID),
@@ -150,7 +147,6 @@ func testAccDefaultSubnet_Existing_ipv6(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
-			acctest.PreCheckRegionNot(t, endpoints.UsWest2RegionID, endpoints.UsGovWest1RegionID)
 			testAccPreCheckDefaultSubnetExists(t)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, ec2.EndpointsID),
@@ -195,7 +191,6 @@ func testAccDefaultSubnet_Existing_privateDnsNameOptionsOnLaunch(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
-			acctest.PreCheckRegionNot(t, endpoints.UsWest2RegionID, endpoints.UsGovWest1RegionID)
 			testAccPreCheckDefaultSubnetExists(t)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, ec2.EndpointsID),
@@ -240,7 +235,6 @@ func testAccDefaultSubnet_NotFound_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
-			acctest.PreCheckRegionNot(t, endpoints.UsWest2RegionID, endpoints.UsGovWest1RegionID)
 			testAccPreCheckDefaultSubnetNotFound(t)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, ec2.EndpointsID),
@@ -284,7 +278,6 @@ func testAccDefaultSubnet_NotFound_ipv6Native(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
-			acctest.PreCheckRegionNot(t, endpoints.UsWest2RegionID, endpoints.UsGovWest1RegionID)
 			testAccPreCheckDefaultSubnetNotFound(t)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, ec2.EndpointsID),

--- a/internal/service/ec2/vpc_default_vpc_dhcp_options.go
+++ b/internal/service/ec2/vpc_default_vpc_dhcp_options.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -108,8 +107,12 @@ func resourceDefaultVPCDHCPOptionsDelete(d *schema.ResourceData, meta interface{
 	return nil
 }
 
+// FIXME: get rid of using aws regions when fixing eip attributes: public_dns, private_dns or
+//  this resource (aws_default_vpc_dhcp_options).
+
 func RegionalPrivateDNSSuffix(region string) string {
-	if region == endpoints.UsEast1RegionID {
+	// lintignore:AWSAT003
+	if region == "us-east-1" {
 		return "ec2.internal"
 	}
 
@@ -117,7 +120,8 @@ func RegionalPrivateDNSSuffix(region string) string {
 }
 
 func RegionalPublicDNSSuffix(region string) string {
-	if region == endpoints.UsEast1RegionID {
+	// lintignore:AWSAT003
+	if region == "us-east-1" {
 		return "compute-1"
 	}
 

--- a/internal/service/ec2/vpc_default_vpc_test.go
+++ b/internal/service/ec2/vpc_default_vpc_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -85,7 +84,6 @@ func testAccDefaultVPC_Existing_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
-			acctest.PreCheckRegionNot(t, endpoints.UsWest2RegionID, endpoints.UsGovWest1RegionID)
 			testAccPreCheckDefaultVPCExists(t)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, ec2.EndpointsID),
@@ -132,7 +130,6 @@ func testAccDefaultVPC_Existing_assignGeneratedIPv6CIDRBlock(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
-			acctest.PreCheckRegionNot(t, endpoints.UsWest2RegionID, endpoints.UsGovWest1RegionID)
 			testAccPreCheckDefaultVPCExists(t)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, ec2.EndpointsID),
@@ -179,7 +176,6 @@ func testAccDefaultVPC_Existing_forceDestroy(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
-			acctest.PreCheckRegionNot(t, endpoints.UsWest2RegionID, endpoints.UsGovWest1RegionID)
 			testAccPreCheckDefaultVPCExists(t)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, ec2.EndpointsID),
@@ -206,7 +202,6 @@ func testAccDefaultVPC_NotFound_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
-			acctest.PreCheckRegionNot(t, endpoints.UsWest2RegionID, endpoints.UsGovWest1RegionID)
 			testAccPreCheckDefaultVPCNotFound(t)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, ec2.EndpointsID),
@@ -253,7 +248,6 @@ func testAccDefaultVPC_NotFound_assignGeneratedIPv6CIDRBlock(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
-			acctest.PreCheckRegionNot(t, endpoints.UsWest2RegionID, endpoints.UsGovWest1RegionID)
 			testAccPreCheckDefaultVPCNotFound(t)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, ec2.EndpointsID),
@@ -300,7 +294,6 @@ func testAccDefaultVPC_NotFound_forceDestroy(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
-			acctest.PreCheckRegionNot(t, endpoints.UsWest2RegionID, endpoints.UsGovWest1RegionID)
 			testAccPreCheckDefaultVPCNotFound(t)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, ec2.EndpointsID),

--- a/internal/service/ec2/vpc_network_interface_test.go
+++ b/internal/service/ec2/vpc_network_interface_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -942,10 +941,12 @@ func convertIPToDashIP(ip string) string {
 	return strings.Replace(ip, ".", "-", -1)
 }
 
+// FIXME: get rid of using aws regions when fixing these tests.
+
 func regionalPrivateDNSSuffix(region string) string {
-	if region == endpoints.UsEast1RegionID {
+	if region == "us-east-1" {
 		return "ec2.internal"
-	}
+	} // lintignore:AWSAT003
 
 	return fmt.Sprintf("%s.compute.internal", region)
 }

--- a/internal/service/ecr/repository.go
+++ b/internal/service/ecr/repository.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -137,7 +136,7 @@ func resourceRepositoryCreate(d *schema.ResourceData, meta interface{}) error {
 	out, err := conn.CreateRepository(&input)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if input.Tags != nil && meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
+	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
 		log.Printf("[WARN] failed creating ECR Repository (%s) with tags: %s. Trying create without tags.", d.Get("name").(string), err)
 		input.Tags = nil
 
@@ -155,7 +154,7 @@ func resourceRepositoryCreate(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(aws.StringValue(repository.RepositoryName))
 
 	// Some partitions (i.e., ISO) may not support tag-on-create, attempt tag after create
-	if input.Tags == nil && len(tags) > 0 && meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID {
+	if input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, aws.StringValue(repository.RepositoryArn), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
@@ -237,7 +236,7 @@ func resourceRepositoryRead(d *schema.ResourceData, meta interface{}) error {
 	tags, err := ListTags(conn, arn)
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
+	if verify.CheckISOErrorTagsUnsupported(err) {
 		log.Printf("[WARN] failed listing tags for ECR Repository (%s): %s", d.Id(), err)
 		return nil
 	}
@@ -248,7 +247,7 @@ func resourceRepositoryRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
-	//lintignore:AWSR002
+	// lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %w", err)
 	}
@@ -327,7 +326,7 @@ func resourceRepositoryUpdate(d *schema.ResourceData, meta interface{}) error {
 		err := UpdateTags(conn, arn, o, n)
 
 		// Some partitions may not support tagging, giving error
-		if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
+		if verify.CheckISOErrorTagsUnsupported(err) {
 			log.Printf("[WARN] failed updating tags for ECR Repository (%s): %s", d.Id(), err)
 			return resourceRepositoryRead(d, meta)
 		}

--- a/internal/service/ecr/repository_data_source.go
+++ b/internal/service/ecr/repository_data_source.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -116,7 +115,7 @@ func dataSourceRepositoryRead(d *schema.ResourceData, meta interface{}) error {
 	tags, err := ListTags(conn, arn)
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
+	if verify.CheckISOErrorTagsUnsupported(err) {
 		log.Printf("[WARN] failed listing tags for ECR Repository (%s): %s", d.Id(), err)
 		return nil
 	}

--- a/internal/service/ecrpublic/repository_test.go
+++ b/internal/service/ecrpublic/repository_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/ecrpublic"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -452,14 +451,6 @@ resource "aws_ecrpublic_repository" "test" {
 }
 
 func testAccPreCheck(t *testing.T) {
-	// At this time, calls to DescribeRepositories returns (and by default, retries)
-	// an InternalFailure when the region is not supported i.e. not us-east-1.
-	// TODO: Remove when ECRPublic is supported across other known regions
-	// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/18047
-	if region := acctest.Provider.Meta().(*conns.AWSClient).Region; region != endpoints.UsEast1RegionID {
-		t.Skipf("skipping acceptance testing: region (%s) does not support ECR Public repositories", region)
-	}
-
 	conn := acctest.Provider.Meta().(*conns.AWSClient).ECRPublicConn
 	input := &ecrpublic.DescribeRepositoriesInput{}
 	_, err := conn.DescribeRepositories(input)

--- a/internal/service/ecs/task_definition_test.go
+++ b/internal/service/ecs/task_definition_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -178,7 +177,7 @@ func TestAccECSTaskDefinition_runtimePlatform(t *testing.T) {
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckPartition(t, endpoints.AwsPartitionID) }, // runtime platform not support on GovCloud
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, ecs.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckTaskDefinitionDestroy,
@@ -212,7 +211,7 @@ func TestAccECSTaskDefinition_Fargate_runtimePlatform(t *testing.T) {
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckPartition(t, endpoints.AwsPartitionID) }, // runtime platform not support on GovCloud
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, ecs.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckTaskDefinitionDestroy,
@@ -246,7 +245,7 @@ func TestAccECSTaskDefinition_Fargate_runtimePlatformWithoutArch(t *testing.T) {
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckPartition(t, endpoints.AwsPartitionID) }, // runtime platform not support on GovCloud
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, ecs.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckTaskDefinitionDestroy,

--- a/internal/service/eks/arn.go
+++ b/internal/service/eks/arn.go
@@ -68,9 +68,8 @@ func Canonicalize(arn string) (string, error) {
 
 func checkPartition(partition string) error {
 	switch partition {
+	// FIXME: get rid of using aws partition after rewriting the tests.
 	case endpoints.AwsPartitionID:
-	case endpoints.AwsCnPartitionID:
-	case endpoints.AwsUsGovPartitionID:
 	default:
 		return fmt.Errorf("partion %q is not recognized", partition)
 	}

--- a/internal/service/eks/fargate_profile_test.go
+++ b/internal/service/eks/fargate_profile_test.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/eks"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -24,7 +23,7 @@ func TestAccEKSFargateProfile_basic(t *testing.T) {
 	resourceName := "aws_eks_fargate_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t); testAccPreCheckFargateProfile(t) },
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, eks.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckFargateProfileDestroy,
@@ -58,7 +57,7 @@ func TestAccEKSFargateProfile_disappears(t *testing.T) {
 	resourceName := "aws_eks_fargate_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t); testAccPreCheckFargateProfile(t) },
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, eks.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckFargateProfileDestroy,
@@ -82,7 +81,7 @@ func TestAccEKSFargateProfile_Multi_profile(t *testing.T) {
 	resourceName2 := "aws_eks_fargate_profile.test.1"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t); testAccPreCheckFargateProfile(t) },
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, eks.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckFargateProfileDestroy,
@@ -104,7 +103,7 @@ func TestAccEKSFargateProfile_Selector_labels(t *testing.T) {
 	resourceName := "aws_eks_fargate_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t); testAccPreCheckFargateProfile(t) },
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, eks.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckFargateProfileDestroy,
@@ -130,7 +129,7 @@ func TestAccEKSFargateProfile_tags(t *testing.T) {
 	resourceName := "aws_eks_fargate_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t); testAccPreCheckFargateProfile(t) },
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, eks.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckFargateProfileDestroy,
@@ -228,59 +227,6 @@ func testAccCheckFargateProfileDestroy(s *terraform.State) error {
 	}
 
 	return nil
-}
-
-func testAccPreCheckFargateProfile(t *testing.T) {
-	// Most PreCheck functions try to use a list or describe API call to
-	// determine service or functionality availability, however
-	// ListFargateProfiles requires a valid ClusterName and does not indicate
-	// that the functionality is unavailable in a region. The create API call
-	// fails with same "ResourceNotFoundException: No cluster found" before
-	// returning the definitive "InvalidRequestException: CreateFargateProfile
-	// is not supported for region" error. We do not want to wait 20 minutes to
-	// create and destroy an EKS Cluster just to find the real error, instead
-	// we take the least desirable approach of hardcoding allowed regions.
-	allowedRegions := []string{
-		endpoints.ApEast1RegionID,
-		endpoints.ApNortheast1RegionID,
-		endpoints.ApNortheast2RegionID,
-		endpoints.ApSouth1RegionID,
-		endpoints.ApSoutheast1RegionID,
-		endpoints.ApSoutheast2RegionID,
-		endpoints.CaCentral1RegionID,
-		endpoints.EuCentral1RegionID,
-		endpoints.EuNorth1RegionID,
-		endpoints.EuWest1RegionID,
-		endpoints.EuWest2RegionID,
-		endpoints.EuWest3RegionID,
-		endpoints.MeSouth1RegionID,
-		endpoints.SaEast1RegionID,
-		endpoints.UsEast1RegionID,
-		endpoints.UsEast2RegionID,
-		endpoints.UsWest1RegionID,
-		endpoints.UsWest2RegionID,
-	}
-	region := acctest.Provider.Meta().(*conns.AWSClient).Region
-
-	for _, allowedRegion := range allowedRegions {
-		if region == allowedRegion {
-			return
-		}
-	}
-
-	message := fmt.Sprintf(`Test provider region (%s) not found in allowed EKS Fargate regions: %v
-
-The allowed regions are hardcoded in the acceptance testing since dynamically determining the
-functionality requires creating and destroying a real EKS Cluster, which is a lengthy process.
-If this check is out of date, please create an issue in the Terraform AWS Provider
-repository (https://github.com/hashicorp/terraform-provider-aws) or submit a PR to update the
-check itself (testAccPreCheckFargateProfile).
-
-For the most up to date supported region information, see the EKS User Guide:
-https://docs.aws.amazon.com/eks/latest/userguide/fargate.html
-`, region, allowedRegions)
-
-	t.Skipf("skipping acceptance testing:\n\n%s", message)
 }
 
 func testAccFargateProfileBaseConfig(rName string) string {

--- a/internal/service/elasticbeanstalk/hosted_zone_data_source.go
+++ b/internal/service/elasticbeanstalk/hosted_zone_data_source.go
@@ -3,37 +3,14 @@ package elasticbeanstalk
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
+// FIXME: get rid of `HostedZoneIDs` and probably of this resource.
+
 // See http://docs.aws.amazon.com/general/latest/gr/rande.html#elasticbeanstalk_region
-var HostedZoneIDs = map[string]string{
-	endpoints.AfSouth1RegionID:     "Z1EI3BVKMKK4AM",
-	endpoints.ApSoutheast1RegionID: "Z16FZ9L249IFLT",
-	endpoints.ApSoutheast2RegionID: "Z2PCDNR3VC2G1N",
-	endpoints.ApEast1RegionID:      "ZPWYUBWRU171A",
-	endpoints.ApNortheast1RegionID: "Z1R25G3KIG2GBW",
-	endpoints.ApNortheast2RegionID: "Z3JE5OI70TWKCP",
-	endpoints.ApNortheast3RegionID: "ZNE5GEY1TIAGY",
-	endpoints.ApSouth1RegionID:     "Z18NTBI3Y7N9TZ",
-	endpoints.CaCentral1RegionID:   "ZJFCZL7SSZB5I",
-	endpoints.EuCentral1RegionID:   "Z1FRNW7UH4DEZJ",
-	endpoints.EuNorth1RegionID:     "Z23GO28BZ5AETM",
-	endpoints.EuSouth1RegionID:     "Z10VDYYOA2JFKM",
-	endpoints.EuWest1RegionID:      "Z2NYPWQ7DFZAZH",
-	endpoints.EuWest2RegionID:      "Z1GKAAAUGATPF1",
-	endpoints.EuWest3RegionID:      "Z5WN6GAYWG5OB",
-	endpoints.MeSouth1RegionID:     "Z2BBTEKR2I36N2",
-	endpoints.SaEast1RegionID:      "Z10X7K2B4QSOFV",
-	endpoints.UsEast1RegionID:      "Z117KPS5GTRQ2G",
-	endpoints.UsEast2RegionID:      "Z14LCN19Q5QHIC",
-	endpoints.UsWest1RegionID:      "Z1LQECGX5PH1X",
-	endpoints.UsWest2RegionID:      "Z38NKT9BP95V3O",
-	endpoints.UsGovEast1RegionID:   "Z35TSARG0EJ4VU",
-	endpoints.UsGovWest1RegionID:   "Z4KAURWC4UUUG",
-}
+var HostedZoneIDs = map[string]string{}
 
 func DataSourceHostedZone() *schema.Resource {
 	return &schema.Resource{

--- a/internal/service/elb/hosted_zone_id_data_source.go
+++ b/internal/service/elb/hosted_zone_id_data_source.go
@@ -3,41 +3,15 @@ package elb
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
+// FIXME: get rid of `HostedZoneIdPerRegionMap` and probably of this resource.
+
 // See http://docs.aws.amazon.com/general/latest/gr/rande.html#elb_region
 // See https://docs.amazonaws.cn/en_us/general/latest/gr/rande.html#elb_region
-var HostedZoneIdPerRegionMap = map[string]string{
-	endpoints.AfSouth1RegionID:     "Z268VQBMOI5EKX",
-	endpoints.ApEast1RegionID:      "Z3DQVH9N71FHZ0",
-	endpoints.ApNortheast1RegionID: "Z14GRHDCWA56QT",
-	endpoints.ApNortheast2RegionID: "ZWKZPGTI48KDX",
-	endpoints.ApNortheast3RegionID: "Z5LXEXXYW11ES",
-	endpoints.ApSouth1RegionID:     "ZP97RAFLXTNZK",
-	endpoints.ApSoutheast1RegionID: "Z1LMS91P8CMLE5",
-	endpoints.ApSoutheast2RegionID: "Z1GM3OXH4ZPM65",
-	endpoints.ApSoutheast3RegionID: "Z08888821HLRG5A9ZRTER",
-	endpoints.CaCentral1RegionID:   "ZQSVJUPU6J1EY",
-	endpoints.CnNorth1RegionID:     "Z1GDH35T77C1KE",
-	endpoints.CnNorthwest1RegionID: "ZM7IZAIOVVDZF",
-	endpoints.EuCentral1RegionID:   "Z215JYRZR1TBD5",
-	endpoints.EuNorth1RegionID:     "Z23TAZ6LKFMNIO",
-	endpoints.EuSouth1RegionID:     "Z3ULH7SSC9OV64",
-	endpoints.EuWest1RegionID:      "Z32O12XQLNTSW2",
-	endpoints.EuWest2RegionID:      "ZHURV8PSTC4K8",
-	endpoints.EuWest3RegionID:      "Z3Q77PNBQS71R4",
-	endpoints.MeSouth1RegionID:     "ZS929ML54UICD",
-	endpoints.SaEast1RegionID:      "Z2P70J7HTTTPLU",
-	endpoints.UsEast1RegionID:      "Z35SXDOTRQ7X7K",
-	endpoints.UsEast2RegionID:      "Z3AADJGX6KTTL2",
-	endpoints.UsGovEast1RegionID:   "Z166TLBEWOO7G0",
-	endpoints.UsGovWest1RegionID:   "Z33AYJ8TM3BH4J",
-	endpoints.UsWest1RegionID:      "Z368ELLRRE2KJ0",
-	endpoints.UsWest2RegionID:      "Z1H1FL5HABSF5",
-}
+var HostedZoneIdPerRegionMap = map[string]string{}
 
 func DataSourceHostedZoneID() *schema.Resource {
 	return &schema.Resource{

--- a/internal/service/elb/service_account_data_source.go
+++ b/internal/service/elb/service_account_data_source.go
@@ -4,41 +4,15 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
+// FIXME: get rid of `AccountIdPerRegionMap` and probably of this resource.
+
 // See http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html#attach-bucket-policy
 // See https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#access-logging-bucket-permissions
-var AccountIdPerRegionMap = map[string]string{
-	endpoints.AfSouth1RegionID:     "098369216593",
-	endpoints.ApEast1RegionID:      "754344448648",
-	endpoints.ApNortheast1RegionID: "582318560864",
-	endpoints.ApNortheast2RegionID: "600734575887",
-	endpoints.ApNortheast3RegionID: "383597477331",
-	endpoints.ApSouth1RegionID:     "718504428378",
-	endpoints.ApSoutheast1RegionID: "114774131450",
-	endpoints.ApSoutheast2RegionID: "783225319266",
-	endpoints.ApSoutheast3RegionID: "589379963580",
-	endpoints.CaCentral1RegionID:   "985666609251",
-	endpoints.CnNorth1RegionID:     "638102146993",
-	endpoints.CnNorthwest1RegionID: "037604701340",
-	endpoints.EuCentral1RegionID:   "054676820928",
-	endpoints.EuNorth1RegionID:     "897822967062",
-	endpoints.EuSouth1RegionID:     "635631232127",
-	endpoints.EuWest1RegionID:      "156460612806",
-	endpoints.EuWest2RegionID:      "652711504416",
-	endpoints.EuWest3RegionID:      "009996457667",
-	endpoints.MeSouth1RegionID:     "076674570225",
-	endpoints.SaEast1RegionID:      "507241528517",
-	endpoints.UsEast1RegionID:      "127311923021",
-	endpoints.UsEast2RegionID:      "033677994240",
-	endpoints.UsGovEast1RegionID:   "190560391635",
-	endpoints.UsGovWest1RegionID:   "048591011584",
-	endpoints.UsWest1RegionID:      "027434742980",
-	endpoints.UsWest2RegionID:      "797873946194",
-}
+var AccountIdPerRegionMap = map[string]string{}
 
 func DataSourceServiceAccount() *schema.Resource {
 	return &schema.Resource{

--- a/internal/service/emr/cluster_test.go
+++ b/internal/service/emr/cluster_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/emr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -80,7 +79,7 @@ func TestAccEMRCluster_autoTerminationPolicy(t *testing.T) {
 	resourceName := "aws_emr_cluster.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckPartitionNot(t, endpoints.AwsUsGovPartitionID) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, emr.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDestroy,
@@ -1127,7 +1126,7 @@ func TestAccEMRCluster_terminationProtected(t *testing.T) {
 				},
 			},
 			{
-				//Need to turn off termination_protection to allow the job to be deleted
+				// Need to turn off termination_protection to allow the job to be deleted
 				Config: testAccClusterTerminationPolicyConfig(rName, "false"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &cluster),

--- a/internal/service/events/target_test.go
+++ b/internal/service/events/target_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/eventbridge"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -133,11 +132,6 @@ func TestAccEventsTarget_eventBusName(t *testing.T) {
 }
 
 func TestAccEventsTarget_eventBusARN(t *testing.T) {
-	// "ValidationException: Adding an EventBus as a target within an account is not allowed."
-	if got, want := acctest.Partition(), endpoints.AwsUsGovPartitionID; got == want {
-		t.Skipf("EventBridge Target EventBus ARNs are not supported in %s partition", got)
-	}
-
 	resourceName := "aws_cloudwatch_event_target.test"
 
 	var target eventbridge.Target

--- a/internal/service/fms/acc_test.go
+++ b/internal/service/fms/acc_test.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/fms"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -66,13 +65,9 @@ func testAccAdminRegionProviderConfig() string {
 	return acctest.ConfigRegionalProvider(testAccGetAdminRegion())
 }
 
+// FIXME: testAccAdminRegion is always "". Fix it, if Firewall Management Service is supported.
+
 // testAccGetAdminRegion returns the Firewall Management Service region for testing
 func testAccGetAdminRegion() string {
-	if testAccAdminRegion != "" {
-		return testAccAdminRegion
-	}
-
-	testAccAdminRegion = endpoints.UsEast1RegionID
-
 	return testAccAdminRegion
 }

--- a/internal/service/fsx/data_repository_association_test.go
+++ b/internal/service/fsx/data_repository_association_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/fsx"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -19,10 +18,6 @@ import (
 )
 
 func TestAccFSxDataRepositoryAssociation_basic(t *testing.T) {
-	if acctest.Partition() == endpoints.AwsUsGovPartitionID {
-		t.Skip("PERSISTENT_2 deployment_type is not supported in GovCloud partition")
-	}
-
 	var association fsx.DataRepositoryAssociation
 	resourceName := "aws_fsx_data_repository_association.test"
 	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,10 +53,6 @@ func TestAccFSxDataRepositoryAssociation_basic(t *testing.T) {
 }
 
 func TestAccFSxDataRepositoryAssociation_disappears(t *testing.T) {
-	if acctest.Partition() == endpoints.AwsUsGovPartitionID {
-		t.Skip("PERSISTENT_2 deployment_type is not supported in GovCloud partition")
-	}
-
 	var association fsx.DataRepositoryAssociation
 	resourceName := "aws_fsx_data_repository_association.test"
 	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -86,10 +77,6 @@ func TestAccFSxDataRepositoryAssociation_disappears(t *testing.T) {
 }
 
 func TestAccFSxDataRepositoryAssociation_disappears_ParentFileSystem(t *testing.T) {
-	if acctest.Partition() == endpoints.AwsUsGovPartitionID {
-		t.Skip("PERSISTENT_2 deployment_type is not supported in GovCloud partition")
-	}
-
 	var association fsx.DataRepositoryAssociation
 	parentResourceName := "aws_fsx_lustre_file_system.test"
 	resourceName := "aws_fsx_data_repository_association.test"
@@ -115,10 +102,6 @@ func TestAccFSxDataRepositoryAssociation_disappears_ParentFileSystem(t *testing.
 }
 
 func TestAccFSxDataRepositoryAssociation_fileSystemPathUpdated(t *testing.T) {
-	if acctest.Partition() == endpoints.AwsUsGovPartitionID {
-		t.Skip("PERSISTENT_2 deployment_type is not supported in GovCloud partition")
-	}
-
 	var association1, association2 fsx.DataRepositoryAssociation
 	resourceName := "aws_fsx_data_repository_association.test"
 	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -157,10 +140,6 @@ func TestAccFSxDataRepositoryAssociation_fileSystemPathUpdated(t *testing.T) {
 }
 
 func TestAccFSxDataRepositoryAssociation_dataRepositoryPathUpdated(t *testing.T) {
-	if acctest.Partition() == endpoints.AwsUsGovPartitionID {
-		t.Skip("PERSISTENT_2 deployment_type is not supported in GovCloud partition")
-	}
-
 	var association1, association2 fsx.DataRepositoryAssociation
 	resourceName := "aws_fsx_data_repository_association.test"
 	bucketName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -202,10 +181,6 @@ func TestAccFSxDataRepositoryAssociation_dataRepositoryPathUpdated(t *testing.T)
 
 // lintignore:AT002
 func TestAccFSxDataRepositoryAssociation_importedFileChunkSize(t *testing.T) {
-	if acctest.Partition() == endpoints.AwsUsGovPartitionID {
-		t.Skip("PERSISTENT_2 deployment_type is not supported in GovCloud partition")
-	}
-
 	var association fsx.DataRepositoryAssociation
 	resourceName := "aws_fsx_data_repository_association.test"
 	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -236,10 +211,6 @@ func TestAccFSxDataRepositoryAssociation_importedFileChunkSize(t *testing.T) {
 
 // lintignore:AT002
 func TestAccFSxDataRepositoryAssociation_importedFileChunkSizeUpdated(t *testing.T) {
-	if acctest.Partition() == endpoints.AwsUsGovPartitionID {
-		t.Skip("PERSISTENT_2 deployment_type is not supported in GovCloud partition")
-	}
-
 	var association1, association2 fsx.DataRepositoryAssociation
 	resourceName := "aws_fsx_data_repository_association.test"
 	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -277,10 +248,6 @@ func TestAccFSxDataRepositoryAssociation_importedFileChunkSizeUpdated(t *testing
 }
 
 func TestAccFSxDataRepositoryAssociation_deleteDataInFilesystem(t *testing.T) {
-	if acctest.Partition() == endpoints.AwsUsGovPartitionID {
-		t.Skip("PERSISTENT_2 deployment_type is not supported in GovCloud partition")
-	}
-
 	var association fsx.DataRepositoryAssociation
 	resourceName := "aws_fsx_data_repository_association.test"
 	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -310,10 +277,6 @@ func TestAccFSxDataRepositoryAssociation_deleteDataInFilesystem(t *testing.T) {
 }
 
 func TestAccFSxDataRepositoryAssociation_s3AutoExportPolicy(t *testing.T) {
-	if acctest.Partition() == endpoints.AwsUsGovPartitionID {
-		t.Skip("PERSISTENT_2 deployment_type is not supported in GovCloud partition")
-	}
-
 	var association fsx.DataRepositoryAssociation
 	resourceName := "aws_fsx_data_repository_association.test"
 	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -346,10 +309,6 @@ func TestAccFSxDataRepositoryAssociation_s3AutoExportPolicy(t *testing.T) {
 }
 
 func TestAccFSxDataRepositoryAssociation_s3AutoExportPolicyUpdate(t *testing.T) {
-	if acctest.Partition() == endpoints.AwsUsGovPartitionID {
-		t.Skip("PERSISTENT_2 deployment_type is not supported in GovCloud partition")
-	}
-
 	var association1, association2 fsx.DataRepositoryAssociation
 	resourceName := "aws_fsx_data_repository_association.test"
 	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -391,10 +350,6 @@ func TestAccFSxDataRepositoryAssociation_s3AutoExportPolicyUpdate(t *testing.T) 
 }
 
 func TestAccFSxDataRepositoryAssociation_s3AutoImportPolicy(t *testing.T) {
-	if acctest.Partition() == endpoints.AwsUsGovPartitionID {
-		t.Skip("PERSISTENT_2 deployment_type is not supported in GovCloud partition")
-	}
-
 	var association fsx.DataRepositoryAssociation
 	resourceName := "aws_fsx_data_repository_association.test"
 	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -427,10 +382,6 @@ func TestAccFSxDataRepositoryAssociation_s3AutoImportPolicy(t *testing.T) {
 }
 
 func TestAccFSxDataRepositoryAssociation_s3AutoImportPolicyUpdate(t *testing.T) {
-	if acctest.Partition() == endpoints.AwsUsGovPartitionID {
-		t.Skip("PERSISTENT_2 deployment_type is not supported in GovCloud partition")
-	}
-
 	var association1, association2 fsx.DataRepositoryAssociation
 	resourceName := "aws_fsx_data_repository_association.test"
 	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -472,10 +423,6 @@ func TestAccFSxDataRepositoryAssociation_s3AutoImportPolicyUpdate(t *testing.T) 
 }
 
 func TestAccFSxDataRepositoryAssociation_s3FullPolicy(t *testing.T) {
-	if acctest.Partition() == endpoints.AwsUsGovPartitionID {
-		t.Skip("PERSISTENT_2 deployment_type is not supported in GovCloud partition")
-	}
-
 	var association fsx.DataRepositoryAssociation
 	resourceName := "aws_fsx_data_repository_association.test"
 	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/fsx/lustre_file_system_test.go
+++ b/internal/service/fsx/lustre_file_system_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/fsx"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -22,9 +21,6 @@ func TestAccFSxLustreFileSystem_basic(t *testing.T) {
 	resourceName := "aws_fsx_lustre_file_system.test"
 
 	deploymentType := fsx.LustreDeploymentTypeScratch1
-	if acctest.Partition() == endpoints.AwsUsGovPartitionID {
-		deploymentType = fsx.LustreDeploymentTypeScratch2 // SCRATCH_1 not supported in GovCloud
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(fsx.EndpointsID, t) },

--- a/internal/service/gamelift/gamelift_test.go
+++ b/internal/service/gamelift/gamelift_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/gamelift"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -18,6 +17,8 @@ type testAccGame struct {
 func (gg *testAccGame) Parameters(portNumber int) string {
 	return fmt.Sprintf("+sv_port %d +gamelift_start_server", portNumber)
 }
+
+// FIXME: tests using `testAccSampleGame` are always skipped. Fix it, if GameLift is supported.
 
 // Location found from CloudTrail event after finishing tutorial
 // e.g. https://us-west-2.console.aws.amazon.com/gamelift/home?region=us-west-2#/r/fleets/sample
@@ -46,22 +47,7 @@ func testAccSampleGame(region string) (*testAccGame, error) {
 
 // Account ID found from CloudTrail event (role ARN) after finishing tutorial in given region
 func testAccAccountIdByRegion(region string) (string, error) {
-	m := map[string]string{
-		endpoints.ApNortheast1RegionID: "120069834884",
-		endpoints.ApNortheast2RegionID: "805673136642",
-		endpoints.ApSouth1RegionID:     "134975661615",
-		endpoints.ApSoutheast1RegionID: "077577004113",
-		endpoints.ApSoutheast2RegionID: "112188327105",
-		endpoints.CaCentral1RegionID:   "800535022691",
-		endpoints.EuCentral1RegionID:   "797584052317",
-		endpoints.EuWest1RegionID:      "319803218673",
-		endpoints.EuWest2RegionID:      "937342764187",
-		endpoints.SaEast1RegionID:      "028872612690",
-		endpoints.UsEast1RegionID:      "783764748367",
-		endpoints.UsEast2RegionID:      "415729564621",
-		endpoints.UsWest1RegionID:      "715879310420",
-		endpoints.UsWest2RegionID:      "741061592171",
-	}
+	m := map[string]string{}
 
 	if accId, ok := m[region]; ok {
 		return accId, nil

--- a/internal/service/iam/access_key_test.go
+++ b/internal/service/iam/access_key_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/iam"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -286,10 +285,14 @@ func TestSesSmtpPasswordFromSecretKeySigV4(t *testing.T) {
 		Input    string
 		Expected string
 	}{
-		{endpoints.EuCentral1RegionID, "some+secret+key", "BMXhUYlu5Z3gSXVQORxlVa7XPaz91aGWdfHxvkOZdWZ2"},
-		{endpoints.EuCentral1RegionID, "another+secret+key", "BBbphbrQmrKMx42d1N6+C7VINYEBGI5v9VsZeTxwskfh"},
-		{endpoints.UsWest1RegionID, "some+secret+key", "BH+jbMzper5WwlwUar9E1ySBqHa9whi0GPo+sJ0mVYJj"},
-		{endpoints.UsWest1RegionID, "another+secret+key", "BKVmjjMDFk/qqw8EROW99bjCS65PF8WKvK5bSr4Y6EqF"},
+		// lintignore:AWSAT003
+		{"eu-central-1", "some+secret+key", "BMXhUYlu5Z3gSXVQORxlVa7XPaz91aGWdfHxvkOZdWZ2"},
+		// lintignore:AWSAT003
+		{"eu-central-1", "another+secret+key", "BBbphbrQmrKMx42d1N6+C7VINYEBGI5v9VsZeTxwskfh"},
+		// lintignore:AWSAT003
+		{"us-west-1", "some+secret+key", "BH+jbMzper5WwlwUar9E1ySBqHa9whi0GPo+sJ0mVYJj"},
+		// lintignore:AWSAT003
+		{"us-west-1", "another+secret+key", "BKVmjjMDFk/qqw8EROW99bjCS65PF8WKvK5bSr4Y6EqF"},
 	}
 
 	for _, tc := range cases {

--- a/internal/service/iam/policy_document_data_source_test.go
+++ b/internal/service/iam/policy_document_data_source_test.go
@@ -265,7 +265,7 @@ func TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePr
 	dataSourceName := "data.aws_iam_policy_document.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckPartition(t, endpoints.AwsUsGovPartitionID) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, iam.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/service/iam/policy_document_data_source_test.go
+++ b/internal/service/iam/policy_document_data_source_test.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -247,7 +246,7 @@ func TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePr
 	dataSourceName := "data.aws_iam_policy_document.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckPartition(t, endpoints.AwsPartitionID) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, iam.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	awspolicy "github.com/hashicorp/awspolicyequivalence"
@@ -202,7 +201,7 @@ func resourceRoleCreate(d *schema.ResourceData, meta interface{}) error {
 	output, err := retryCreateRole(conn, request)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if request.Tags != nil && meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
+	if request.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
 		log.Printf("[WARN] failed creating IAM Role (%s) with tags: %s. Trying create without tags.", name, err)
 		request.Tags = nil
 
@@ -232,7 +231,7 @@ func resourceRoleCreate(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(roleName)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create, attempt tag after create
-	if request.Tags == nil && len(tags) > 0 && meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID {
+	if request.Tags == nil && len(tags) > 0 {
 		err := roleUpdateTags(conn, d.Id(), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
@@ -321,7 +320,7 @@ func resourceRoleRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags := KeyValueTags(role.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
-	//lintignore:AWSR002
+	// lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %w", err)
 	}
@@ -485,7 +484,7 @@ func resourceRoleUpdate(d *schema.ResourceData, meta interface{}) error {
 		err := roleUpdateTags(conn, d.Id(), o, n)
 
 		// Some partitions may not support tagging, giving error
-		if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
+		if verify.CheckISOErrorTagsUnsupported(err) {
 			log.Printf("[WARN] failed updating tags for IAM Role %s: %s", d.Id(), err)
 			return resourceRoleRead(d, meta)
 		}

--- a/internal/service/keyspaces/keyspace_test.go
+++ b/internal/service/keyspaces/keyspace_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/keyspaces"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -16,21 +15,12 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func testAccPreCheck(t *testing.T) {
-	// Checking for service fails in all partitions!
-	// acctest.PreCheckPartitionHasService(keyspaces.EndpointsID, t)
-
-	if got, want := acctest.Partition(), endpoints.AwsUsGovPartitionID; got == want {
-		t.Skipf("Keyspaces is not supported in %s partition", got)
-	}
-}
-
 func TestAccKeyspacesKeyspace_basic(t *testing.T) {
 	rName := "tf_test_" + sdkacctest.RandString(8)
 	resourceName := "aws_keyspaces_keyspace.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, keyspaces.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckKeyspaceDestroy,
@@ -58,7 +48,7 @@ func TestAccKeyspacesKeyspace_disappears(t *testing.T) {
 	resourceName := "aws_keyspaces_keyspace.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, keyspaces.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckKeyspaceDestroy,
@@ -80,7 +70,7 @@ func TestAccKeyspacesKeyspace_tags(t *testing.T) {
 	resourceName := "aws_keyspaces_keyspace.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, keyspaces.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckKeyspaceDestroy,

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -709,7 +708,7 @@ func resourceFunctionRead(d *schema.ResourceData, meta interface{}) error {
 	if !qualifierExistance {
 		tags := KeyValueTags(getFunctionOutput.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
-		//lintignore:AWSR002
+		// lintignore:AWSR002
 		if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
 			return fmt.Errorf("error setting tags: %w", err)
 		}
@@ -885,22 +884,6 @@ func resourceFunctionRead(d *schema.ResourceData, meta interface{}) error {
 
 	invokeArn := functionInvokeArn(*function.FunctionArn, meta)
 	d.Set("invoke_arn", invokeArn)
-
-	// Currently, this functionality is only enabled in AWS Commercial partition
-	// and other partitions return ambiguous error codes (e.g. AccessDeniedException
-	// in AWS GovCloud (US)) so we cannot just ignore the error as would typically.
-	if partition := meta.(*conns.AWSClient).Partition; partition != endpoints.AwsPartitionID {
-		return nil
-	}
-
-	// Currently, this functionality is not enabled in ap-northeast-3 (Osaka) and ap-southeast-3 (Jakarta) region
-	// and returns ambiguous error codes (e.g. AccessDeniedException)
-	// so we cannot just ignore the error as would typically.
-	// We are hardcoding the region here, because go aws sdk endpoints
-	// package does not support Signer service
-	if region := meta.(*conns.AWSClient).Region; region == endpoints.ApNortheast3RegionID || region == endpoints.ApSoutheast3RegionID {
-		return nil
-	}
 
 	// Code Signing is only supported on zip packaged lambda functions.
 	var codeSigningConfigArn string

--- a/internal/service/lambda/function_data_source.go
+++ b/internal/service/lambda/function_data_source.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -331,15 +330,6 @@ func dataSourceFunctionRead(d *schema.ResourceData, meta interface{}) error {
 
 	if err := d.Set("file_system_config", flattenFileSystemConfigs(function.FileSystemConfigs)); err != nil {
 		return fmt.Errorf("error setting file_system_config: %w", err)
-	}
-
-	// Currently, this functionality is only enabled in AWS Commercial partition
-	// and other partitions return ambiguous error codes (e.g. AccessDeniedException
-	// in AWS GovCloud (US)) so we cannot just ignore the error as would typically.
-	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID {
-		d.SetId(aws.StringValue(function.FunctionName))
-
-		return nil
 	}
 
 	// Get Code Signing Config Output.

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/aws/aws-sdk-go/service/signer"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -165,18 +164,6 @@ func TestAccLambdaFunction_disappears(t *testing.T) {
 }
 
 func TestAccLambdaFunction_codeSigning(t *testing.T) {
-	if got, want := acctest.Partition(), endpoints.AwsUsGovPartitionID; got == want {
-		t.Skipf("Lambda code signing config is not supported in %s partition", got)
-	}
-
-	// We are hardcoding the region here, because go aws sdk endpoints
-	// package does not support Signer service
-	for _, want := range []string{endpoints.ApNortheast3RegionID, endpoints.ApSoutheast3RegionID} {
-		if got := acctest.Region(); got == want {
-			t.Skipf("Lambda code signing config is not supported in %s region", got)
-		}
-	}
-
 	var conf lambda.GetFunctionOutput
 	rString := sdkacctest.RandString(8)
 	funcName := fmt.Sprintf("tf_acc_lambda_func_csc_%s", rString)
@@ -1245,10 +1232,6 @@ func TestAccLambdaFunction_ephemeralStorage(t *testing.T) {
 func TestAccLambdaFunction_tracing(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
-	}
-
-	if got, want := acctest.Partition(), endpoints.AwsUsGovPartitionID; got == want {
-		t.Skipf("Lambda tracing config is not supported in %s partition", got)
 	}
 
 	var conf lambda.GetFunctionOutput

--- a/internal/service/lambda/function_url_data_source_test.go
+++ b/internal/service/lambda/function_url_data_source_test.go
@@ -16,7 +16,7 @@ func TestAccLambdaFunctionURLDataSource_basic(t *testing.T) {
 	resourceName := "aws_lambda_function_url.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccFunctionURLPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, lambda.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/service/lambda/function_url_test.go
+++ b/internal/service/lambda/function_url_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -16,10 +15,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func testAccFunctionURLPreCheck(t *testing.T) {
-	acctest.PreCheckPartition(t, endpoints.AwsPartitionID)
-}
-
 func TestAccLambdaFunctionURL_basic(t *testing.T) {
 	var conf lambda.GetFunctionUrlConfigOutput
 	resourceName := "aws_lambda_function_url.test"
@@ -29,7 +24,7 @@ func TestAccLambdaFunctionURL_basic(t *testing.T) {
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_basic_%s", rString)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccFunctionURLPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, lambda.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckFunctionURLDestroy,
@@ -66,7 +61,7 @@ func TestAccLambdaFunctionURL_Cors(t *testing.T) {
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_basic_%s", rString)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccFunctionURLPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, lambda.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckFunctionURLDestroy,
@@ -131,7 +126,7 @@ func TestAccLambdaFunctionURL_Alias(t *testing.T) {
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_basic_%s", rString)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccFunctionURLPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, lambda.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckFunctionURLDestroy,
@@ -164,7 +159,7 @@ func TestAccLambdaFunctionURL_TwoURLs(t *testing.T) {
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_basic_%s", rString)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccFunctionURLPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, lambda.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckFunctionURLDestroy,

--- a/internal/service/lightsail/acc_test.go
+++ b/internal/service/lightsail/acc_test.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/lightsail"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -71,22 +70,12 @@ func testAccPreCheckDomain(t *testing.T) {
 // Testing Lightsail Domains assumes no other provider configurations
 // are necessary and overwrites the "aws" provider configuration.
 func testAccDomainRegionProviderConfig() string {
-	return acctest.ConfigRegionalProvider(testAccGetDomainRegion())
+	return acctest.ConfigRegionalProvider(testAccLightsailDomainRegion)
 }
+
+// FIXME: testAccLightsailDomainRegion is always "". Fix it, if Lightsail Domains are supported.
 
 // testAccGetDomainRegion returns the Lightsail Domains region for testing
 func testAccGetDomainRegion() string {
-	if testAccLightsailDomainRegion != "" {
-		return testAccLightsailDomainRegion
-	}
-
-	// AWS Commercial: https://lightsail.aws.amazon.com/ls/docs/en_us/articles/lightsail-how-to-create-dns-entry
-	// AWS GovCloud (US) - service not supported: https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/using-services.html
-	// AWS China - service not supported: https://www.amazonaws.cn/en/about-aws/regional-product-services/
-	switch acctest.Partition() {
-	case endpoints.AwsPartitionID:
-		testAccLightsailDomainRegion = endpoints.UsEast1RegionID
-	}
-
 	return testAccLightsailDomainRegion
 }

--- a/internal/service/memorydb/acl_data_source_test.go
+++ b/internal/service/memorydb/acl_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccMemoryDBACLDataSource_basic(t *testing.T) {
 	userName2 := "tf-" + sdkacctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/service/memorydb/acl_test.go
+++ b/internal/service/memorydb/acl_test.go
@@ -22,7 +22,7 @@ func TestAccMemoryDBACL_basic(t *testing.T) {
 	resourceName := "aws_memorydb_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckACLDestroy,
@@ -54,7 +54,7 @@ func TestAccMemoryDBACL_disappears(t *testing.T) {
 	resourceName := "aws_memorydb_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckACLDestroy,
@@ -75,7 +75,7 @@ func TestAccMemoryDBACL_nameGenerated(t *testing.T) {
 	resourceName := "aws_memorydb_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckACLDestroy,
@@ -96,7 +96,7 @@ func TestAccMemoryDBACL_namePrefix(t *testing.T) {
 	resourceName := "aws_memorydb_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckACLDestroy,
@@ -118,7 +118,7 @@ func TestAccMemoryDBACL_update_tags(t *testing.T) {
 	resourceName := "aws_memorydb_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckACLDestroy,
@@ -193,7 +193,7 @@ func TestAccMemoryDBACL_update_userNames(t *testing.T) {
 	resourceName := "aws_memorydb_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckACLDestroy,

--- a/internal/service/memorydb/cluster_data_source_test.go
+++ b/internal/service/memorydb/cluster_data_source_test.go
@@ -16,7 +16,7 @@ func TestAccMemoryDBClusterDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_memorydb_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/service/memorydb/cluster_test.go
+++ b/internal/service/memorydb/cluster_test.go
@@ -22,7 +22,7 @@ func TestAccMemoryDBCluster_basic(t *testing.T) {
 	resourceName := "aws_memorydb_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckClusterDestroy,
@@ -82,7 +82,7 @@ func TestAccMemoryDBCluster_defaults(t *testing.T) {
 	resourceName := "aws_memorydb_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckClusterDestroy,
@@ -130,7 +130,7 @@ func TestAccMemoryDBCluster_disappears(t *testing.T) {
 	resourceName := "aws_memorydb_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckClusterDestroy,
@@ -152,7 +152,7 @@ func TestAccMemoryDBCluster_nameGenerated(t *testing.T) {
 	resourceName := "aws_memorydb_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckClusterDestroy,
@@ -174,7 +174,7 @@ func TestAccMemoryDBCluster_namePrefix(t *testing.T) {
 	resourceName := "aws_memorydb_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckClusterDestroy,
@@ -198,7 +198,7 @@ func TestAccMemoryDBCluster_create_noTLS(t *testing.T) {
 	resourceName := "aws_memorydb_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckClusterDestroy,
@@ -224,7 +224,7 @@ func TestAccMemoryDBCluster_create_withKMS(t *testing.T) {
 	resourceName := "aws_memorydb_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckClusterDestroy,
@@ -250,7 +250,7 @@ func TestAccMemoryDBCluster_create_withPort(t *testing.T) {
 	resourceName := "aws_memorydb_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckClusterDestroy,
@@ -277,7 +277,7 @@ func TestAccMemoryDBCluster_create_fromSnapshot(t *testing.T) {
 	rName2 := "tf-test-" + sdkacctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckClusterDestroy,
@@ -298,7 +298,7 @@ func TestAccMemoryDBCluster_delete_withFinalSnapshot(t *testing.T) {
 	resourceName := "aws_memorydb_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckClusterDestroy,
@@ -344,7 +344,7 @@ func TestAccMemoryDBCluster_update_aclName(t *testing.T) {
 	resourceName := "aws_memorydb_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckClusterDestroy,
@@ -382,7 +382,7 @@ func TestAccMemoryDBCluster_update_description(t *testing.T) {
 	resourceName := "aws_memorydb_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckClusterDestroy,
@@ -438,7 +438,7 @@ func TestAccMemoryDBCluster_update_engineVersion(t *testing.T) {
 	resourceName := "aws_memorydb_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckClusterDestroy,
@@ -476,7 +476,7 @@ func TestAccMemoryDBCluster_update_maintenanceWindow(t *testing.T) {
 	resourceName := "aws_memorydb_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckClusterDestroy,
@@ -514,7 +514,7 @@ func TestAccMemoryDBCluster_update_nodeType(t *testing.T) {
 	resourceName := "aws_memorydb_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckClusterDestroy,
@@ -555,7 +555,7 @@ func TestAccMemoryDBCluster_update_numShards_scaleUp(t *testing.T) {
 	resourceName := "aws_memorydb_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckClusterDestroy,
@@ -591,7 +591,7 @@ func TestAccMemoryDBCluster_update_numShards_scaleDown(t *testing.T) {
 	resourceName := "aws_memorydb_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckClusterDestroy,
@@ -627,7 +627,7 @@ func TestAccMemoryDBCluster_update_numReplicasPerShard_scaleUp(t *testing.T) {
 	resourceName := "aws_memorydb_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckClusterDestroy,
@@ -663,7 +663,7 @@ func TestAccMemoryDBCluster_update_numReplicasPerShard_scaleDown(t *testing.T) {
 	resourceName := "aws_memorydb_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckClusterDestroy,
@@ -696,7 +696,7 @@ func TestAccMemoryDBCluster_update_parameterGroup(t *testing.T) {
 	resourceName := "aws_memorydb_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckClusterDestroy,
@@ -741,7 +741,7 @@ func TestAccMemoryDBCluster_update_securityGroupIds(t *testing.T) {
 	resourceName := "aws_memorydb_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckClusterDestroy,
@@ -799,7 +799,7 @@ func TestAccMemoryDBCluster_update_snapshotRetentionLimit(t *testing.T) {
 	resourceName := "aws_memorydb_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckClusterDestroy,
@@ -849,7 +849,7 @@ func TestAccMemoryDBCluster_update_snapshotWindow(t *testing.T) {
 	resourceName := "aws_memorydb_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckClusterDestroy,
@@ -887,7 +887,7 @@ func TestAccMemoryDBCluster_update_snsTopicArn(t *testing.T) {
 	resourceName := "aws_memorydb_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckClusterDestroy,
@@ -937,7 +937,7 @@ func TestAccMemoryDBCluster_update_tags(t *testing.T) {
 	resourceName := "aws_memorydb_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckClusterDestroy,

--- a/internal/service/memorydb/parameter_group_data_source_test.go
+++ b/internal/service/memorydb/parameter_group_data_source_test.go
@@ -16,7 +16,7 @@ func TestAccMemoryDBParameterGroupDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_memorydb_parameter_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/service/memorydb/parameter_group_test.go
+++ b/internal/service/memorydb/parameter_group_test.go
@@ -23,7 +23,7 @@ func TestAccMemoryDBParameterGroup_basic(t *testing.T) {
 	resourceName := "aws_memorydb_parameter_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckParameterGroupDestroy,
@@ -64,7 +64,7 @@ func TestAccMemoryDBParameterGroup_disappears(t *testing.T) {
 	resourceName := "aws_memorydb_parameter_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckParameterGroupDestroy,
@@ -86,7 +86,7 @@ func TestAccMemoryDBParameterGroup_update_parameters(t *testing.T) {
 	resourceName := "aws_memorydb_parameter_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckParameterGroupDestroy,
@@ -195,7 +195,7 @@ func TestAccMemoryDBParameterGroup_update_tags(t *testing.T) {
 	resourceName := "aws_memorydb_parameter_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckSubnetGroupDestroy,

--- a/internal/service/memorydb/snapshot_data_source_test.go
+++ b/internal/service/memorydb/snapshot_data_source_test.go
@@ -16,7 +16,7 @@ func TestAccMemoryDBSnapshotDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_memorydb_snapshot.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/service/memorydb/snapshot_test.go
+++ b/internal/service/memorydb/snapshot_test.go
@@ -21,7 +21,7 @@ func TestAccMemoryDBSnapshot_basic(t *testing.T) {
 	resourceName := "aws_memorydb_snapshot.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckSnapshotDestroy,
@@ -65,7 +65,7 @@ func TestAccMemoryDBSnapshot_disappears(t *testing.T) {
 	resourceName := "aws_memorydb_snapshot.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckSnapshotDestroy,
@@ -87,7 +87,7 @@ func TestAccMemoryDBSnapshot_nameGenerated(t *testing.T) {
 	resourceName := "aws_memorydb_snapshot.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckSnapshotDestroy,
@@ -109,7 +109,7 @@ func TestAccMemoryDBSnapshot_namePrefix(t *testing.T) {
 	resourceName := "aws_memorydb_snapshot.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckSnapshotDestroy,
@@ -131,7 +131,7 @@ func TestAccMemoryDBSnapshot_create_withKMS(t *testing.T) {
 	resourceName := "aws_memorydb_snapshot.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckSnapshotDestroy,
@@ -157,7 +157,7 @@ func TestAccMemoryDBSnapshot_update_tags(t *testing.T) {
 	resourceName := "aws_memorydb_snapshot.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckSnapshotDestroy,

--- a/internal/service/memorydb/subnet_group_data_source_test.go
+++ b/internal/service/memorydb/subnet_group_data_source_test.go
@@ -16,7 +16,7 @@ func TestAccMemoryDBSubnetGroupDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_memorydb_subnet_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/service/memorydb/subnet_group_test.go
+++ b/internal/service/memorydb/subnet_group_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/memorydb"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -17,21 +16,12 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func testAccPreCheck(t *testing.T) {
-	// Checking for service fails in all partitions!
-	// acctest.PreCheckPartitionHasService(memorydb.EndpointsID, t)
-
-	if got, want := acctest.Partition(), endpoints.AwsUsGovPartitionID; got == want {
-		t.Skipf("MemoryDB is not supported in %s partition", got)
-	}
-}
-
 func TestAccMemoryDBSubnetGroup_basic(t *testing.T) {
 	rName := "tf-test-" + sdkacctest.RandString(8)
 	resourceName := "aws_memorydb_subnet_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckSubnetGroupDestroy,
@@ -65,7 +55,7 @@ func TestAccMemoryDBSubnetGroup_disappears(t *testing.T) {
 	resourceName := "aws_memorydb_subnet_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckSubnetGroupDestroy,
@@ -87,7 +77,7 @@ func TestAccMemoryDBSubnetGroup_nameGenerated(t *testing.T) {
 	resourceName := "aws_memorydb_subnet_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckSubnetGroupDestroy,
@@ -109,7 +99,7 @@ func TestAccMemoryDBSubnetGroup_namePrefix(t *testing.T) {
 	resourceName := "aws_memorydb_subnet_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckSubnetGroupDestroy,
@@ -131,7 +121,7 @@ func TestAccMemoryDBSubnetGroup_update_description(t *testing.T) {
 	resourceName := "aws_memorydb_subnet_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckSubnetGroupDestroy,
@@ -169,7 +159,7 @@ func TestAccMemoryDBSubnetGroup_update_subnetIds(t *testing.T) {
 	resourceName := "aws_memorydb_subnet_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckSubnetGroupDestroy,
@@ -225,7 +215,7 @@ func TestAccMemoryDBSubnetGroup_update_tags(t *testing.T) {
 	resourceName := "aws_memorydb_subnet_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckSubnetGroupDestroy,

--- a/internal/service/memorydb/user_data_source_test.go
+++ b/internal/service/memorydb/user_data_source_test.go
@@ -16,7 +16,7 @@ func TestAccMemoryDBUserDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_memorydb_user.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/service/memorydb/user_test.go
+++ b/internal/service/memorydb/user_test.go
@@ -20,7 +20,7 @@ func TestAccMemoryDBUser_basic(t *testing.T) {
 	resourceName := "aws_memorydb_user.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckUserDestroy,
@@ -56,7 +56,7 @@ func TestAccMemoryDBUser_disappears(t *testing.T) {
 	resourceName := "aws_memorydb_user.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckUserDestroy,
@@ -78,7 +78,7 @@ func TestAccMemoryDBUser_update_accessString(t *testing.T) {
 	resourceName := "aws_memorydb_user.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckUserDestroy,
@@ -112,7 +112,7 @@ func TestAccMemoryDBUser_update_passwords(t *testing.T) {
 	resourceName := "aws_memorydb_user.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckUserDestroy,
@@ -165,7 +165,7 @@ func TestAccMemoryDBUser_update_tags(t *testing.T) {
 	resourceName := "aws_memorydb_user.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, memorydb.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckUserDestroy,

--- a/internal/service/meta/arn_data_source_test.go
+++ b/internal/service/meta/arn_data_source_test.go
@@ -17,8 +17,8 @@ func TestAccMetaARNDataSource_basic(t *testing.T) {
 
 	testARN := arn.ARN{
 		AccountID: "123456789012",
-		Partition: endpoints.AwsPartitionID,
-		Region:    endpoints.EuWest1RegionID,
+		Partition: "c2",
+		Region:    endpoints.RuMskRegionID,
 		Resource:  "db:mysql-db",
 		Service:   "rds",
 	}

--- a/internal/service/meta/region_data_source_test.go
+++ b/internal/service/meta/region_data_source_test.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -29,7 +30,7 @@ func TestFindRegionByEc2Endpoint(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    "ec2.us-east-1.amazonaws.com", // lintignore:AWSAT003
+			Value:    fmt.Sprintf("ec2.%s.%s", endpoints.RuMskRegionID, endpoints.K2Partition().DNSSuffix()),
 			ErrCount: 0,
 		},
 	}
@@ -59,7 +60,7 @@ func TestFindRegionByName(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    "us-east-1", // lintignore:AWSAT003
+			Value:    endpoints.RuMskRegionID,
 			ErrCount: 0,
 		},
 	}

--- a/internal/service/meta/service_data_source_test.go
+++ b/internal/service/meta/service_data_source_test.go
@@ -1,17 +1,9 @@
 package meta_test
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/rds"
-	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/service/waf"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfmeta "github.com/hashicorp/terraform-provider-aws/internal/service/meta"
 )
 
@@ -47,161 +39,163 @@ func TestInvertStringSlice(t *testing.T) {
 	}
 }
 
-func TestAccMetaService_basic(t *testing.T) {
-	dataSourceName := "data.aws_service.default"
+// FIXME: rewrite commented out acc tests after supporting data source aws_service.
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t, tfmeta.PseudoServiceID),
-		ProviderFactories: acctest.ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckServiceConfig_basic(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "dns_name", fmt.Sprintf("%s.%s.%s", ec2.EndpointsID, acctest.Region(), "amazonaws.com")),
-					resource.TestCheckResourceAttr(dataSourceName, "partition", acctest.Partition()),
-					resource.TestCheckResourceAttr(dataSourceName, "reverse_dns_prefix", "com.amazonaws"),
-					resource.TestCheckResourceAttr(dataSourceName, "region", acctest.Region()),
-					resource.TestCheckResourceAttr(dataSourceName, "reverse_dns_name", fmt.Sprintf("%s.%s.%s", "com.amazonaws", acctest.Region(), ec2.EndpointsID)),
-					resource.TestCheckResourceAttr(dataSourceName, "service_id", ec2.EndpointsID),
-					resource.TestCheckResourceAttr(dataSourceName, "supported", "true"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccMetaService_byReverseDNSName(t *testing.T) {
-	dataSourceName := "data.aws_service.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t, tfmeta.PseudoServiceID),
-		ProviderFactories: acctest.ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckServiceConfig_byReverseDNSName(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "region", endpoints.CnNorth1RegionID),
-					resource.TestCheckResourceAttr(dataSourceName, "reverse_dns_name", fmt.Sprintf("%s.%s.%s", "cn.com.amazonaws", endpoints.CnNorth1RegionID, s3.EndpointsID)),
-					resource.TestCheckResourceAttr(dataSourceName, "reverse_dns_prefix", "cn.com.amazonaws"),
-					resource.TestCheckResourceAttr(dataSourceName, "service_id", s3.EndpointsID),
-					resource.TestCheckResourceAttr(dataSourceName, "supported", "true"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccMetaService_byDNSName(t *testing.T) {
-	dataSourceName := "data.aws_service.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t, tfmeta.PseudoServiceID),
-		ProviderFactories: acctest.ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckServiceConfig_byDNSName(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "region", endpoints.UsEast1RegionID),
-					resource.TestCheckResourceAttr(dataSourceName, "reverse_dns_name", fmt.Sprintf("%s.%s.%s", "com.amazonaws", endpoints.UsEast1RegionID, rds.EndpointsID)),
-					resource.TestCheckResourceAttr(dataSourceName, "reverse_dns_prefix", "com.amazonaws"),
-					resource.TestCheckResourceAttr(dataSourceName, "service_id", rds.EndpointsID),
-					resource.TestCheckResourceAttr(dataSourceName, "supported", "true"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccMetaService_byParts(t *testing.T) {
-	dataSourceName := "data.aws_service.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t, tfmeta.PseudoServiceID),
-		ProviderFactories: acctest.ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckServiceConfig_byPart(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "dns_name", fmt.Sprintf("%s.%s.%s", s3.EndpointsID, acctest.Region(), "amazonaws.com")),
-					resource.TestCheckResourceAttr(dataSourceName, "reverse_dns_name", fmt.Sprintf("%s.%s.%s", "com.amazonaws", acctest.Region(), s3.EndpointsID)),
-					resource.TestCheckResourceAttr(dataSourceName, "supported", "true"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccMetaService_unsupported(t *testing.T) {
-	dataSourceName := "data.aws_service.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t, tfmeta.PseudoServiceID),
-		ProviderFactories: acctest.ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckServiceConfig_unsupported(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "dns_name", fmt.Sprintf("%s.%s.%s", waf.EndpointsID, endpoints.UsGovWest1RegionID, "amazonaws.com")),
-					resource.TestCheckResourceAttr(dataSourceName, "partition", endpoints.AwsUsGovPartitionID),
-					resource.TestCheckResourceAttr(dataSourceName, "reverse_dns_prefix", "com.amazonaws"),
-					resource.TestCheckResourceAttr(dataSourceName, "region", endpoints.UsGovWest1RegionID),
-					resource.TestCheckResourceAttr(dataSourceName, "reverse_dns_name", fmt.Sprintf("%s.%s.%s", "com.amazonaws", endpoints.UsGovWest1RegionID, waf.EndpointsID)),
-					resource.TestCheckResourceAttr(dataSourceName, "service_id", waf.EndpointsID),
-					resource.TestCheckResourceAttr(dataSourceName, "supported", "false"),
-				),
-			},
-		},
-	})
-}
-
-func testAccCheckServiceConfig_basic() string {
-	return fmt.Sprintf(`
-data "aws_service" "default" {
-  service_id = %[1]q
-}
-`, ec2.EndpointsID)
-}
-
-func testAccCheckServiceConfig_byReverseDNSName() string {
-	// lintignore:AWSAT003
-	return `
-data "aws_service" "test" {
-  reverse_dns_name = "cn.com.amazonaws.cn-north-1.s3"
-}
-`
-}
-
-func testAccCheckServiceConfig_byDNSName() string {
-	// lintignore:AWSAT003
-	return `
-data "aws_service" "test" {
-  dns_name = "rds.us-east-1.amazonaws.com"
-}
-`
-}
-
-func testAccCheckServiceConfig_byPart() string {
-	return `
-data "aws_region" "current" {}
-
-data "aws_service" "test" {
-  reverse_dns_prefix = "com.amazonaws"
-  region             = data.aws_region.current.name
-  service_id         = "s3"
-}
-`
-}
-
-func testAccCheckServiceConfig_unsupported() string {
-	// lintignore:AWSAT003
-	return `
-data "aws_service" "test" {
-  reverse_dns_name = "com.amazonaws.us-gov-west-1.waf"
-}
-`
-}
+// func TestAccMetaService_basic(t *testing.T) {
+// 	dataSourceName := "data.aws_service.default"
+//
+// 	resource.ParallelTest(t, resource.TestCase{
+// 		PreCheck:          func() { acctest.PreCheck(t) },
+// 		ErrorCheck:        acctest.ErrorCheck(t, tfmeta.PseudoServiceID),
+// 		ProviderFactories: acctest.ProviderFactories,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccCheckServiceConfig_basic(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(dataSourceName, "dns_name", fmt.Sprintf("%s.%s.%s", ec2.EndpointsID, acctest.Region(), "amazonaws.com")),
+// 					resource.TestCheckResourceAttr(dataSourceName, "partition", acctest.Partition()),
+// 					resource.TestCheckResourceAttr(dataSourceName, "reverse_dns_prefix", "com.amazonaws"),
+// 					resource.TestCheckResourceAttr(dataSourceName, "region", acctest.Region()),
+// 					resource.TestCheckResourceAttr(dataSourceName, "reverse_dns_name", fmt.Sprintf("%s.%s.%s", "com.amazonaws", acctest.Region(), ec2.EndpointsID)),
+// 					resource.TestCheckResourceAttr(dataSourceName, "service_id", ec2.EndpointsID),
+// 					resource.TestCheckResourceAttr(dataSourceName, "supported", "true"),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
+//
+// func TestAccMetaService_byReverseDNSName(t *testing.T) {
+// 	dataSourceName := "data.aws_service.test"
+//
+// 	resource.ParallelTest(t, resource.TestCase{
+// 		PreCheck:          func() { acctest.PreCheck(t) },
+// 		ErrorCheck:        acctest.ErrorCheck(t, tfmeta.PseudoServiceID),
+// 		ProviderFactories: acctest.ProviderFactories,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccCheckServiceConfig_byReverseDNSName(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(dataSourceName, "region", endpoints.CnNorth1RegionID),
+// 					resource.TestCheckResourceAttr(dataSourceName, "reverse_dns_name", fmt.Sprintf("%s.%s.%s", "cn.com.amazonaws", endpoints.CnNorth1RegionID, s3.EndpointsID)),
+// 					resource.TestCheckResourceAttr(dataSourceName, "reverse_dns_prefix", "cn.com.amazonaws"),
+// 					resource.TestCheckResourceAttr(dataSourceName, "service_id", s3.EndpointsID),
+// 					resource.TestCheckResourceAttr(dataSourceName, "supported", "true"),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
+//
+// func TestAccMetaService_byDNSName(t *testing.T) {
+// 	dataSourceName := "data.aws_service.test"
+//
+// 	resource.ParallelTest(t, resource.TestCase{
+// 		PreCheck:          func() { acctest.PreCheck(t) },
+// 		ErrorCheck:        acctest.ErrorCheck(t, tfmeta.PseudoServiceID),
+// 		ProviderFactories: acctest.ProviderFactories,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccCheckServiceConfig_byDNSName(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(dataSourceName, "region", endpoints.UsEast1RegionID),
+// 					resource.TestCheckResourceAttr(dataSourceName, "reverse_dns_name", fmt.Sprintf("%s.%s.%s", "com.amazonaws", endpoints.UsEast1RegionID, rds.EndpointsID)),
+// 					resource.TestCheckResourceAttr(dataSourceName, "reverse_dns_prefix", "com.amazonaws"),
+// 					resource.TestCheckResourceAttr(dataSourceName, "service_id", rds.EndpointsID),
+// 					resource.TestCheckResourceAttr(dataSourceName, "supported", "true"),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
+//
+// func TestAccMetaService_byParts(t *testing.T) {
+// 	dataSourceName := "data.aws_service.test"
+//
+// 	resource.ParallelTest(t, resource.TestCase{
+// 		PreCheck:          func() { acctest.PreCheck(t) },
+// 		ErrorCheck:        acctest.ErrorCheck(t, tfmeta.PseudoServiceID),
+// 		ProviderFactories: acctest.ProviderFactories,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccCheckServiceConfig_byPart(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(dataSourceName, "dns_name", fmt.Sprintf("%s.%s.%s", s3.EndpointsID, acctest.Region(), "amazonaws.com")),
+// 					resource.TestCheckResourceAttr(dataSourceName, "reverse_dns_name", fmt.Sprintf("%s.%s.%s", "com.amazonaws", acctest.Region(), s3.EndpointsID)),
+// 					resource.TestCheckResourceAttr(dataSourceName, "supported", "true"),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
+//
+// func TestAccMetaService_unsupported(t *testing.T) {
+// 	dataSourceName := "data.aws_service.test"
+//
+// 	resource.ParallelTest(t, resource.TestCase{
+// 		PreCheck:          func() { acctest.PreCheck(t) },
+// 		ErrorCheck:        acctest.ErrorCheck(t, tfmeta.PseudoServiceID),
+// 		ProviderFactories: acctest.ProviderFactories,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccCheckServiceConfig_unsupported(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(dataSourceName, "dns_name", fmt.Sprintf("%s.%s.%s", waf.EndpointsID, endpoints.UsGovWest1RegionID, "amazonaws.com")),
+// 					resource.TestCheckResourceAttr(dataSourceName, "partition", endpoints.AwsUsGovPartitionID),
+// 					resource.TestCheckResourceAttr(dataSourceName, "reverse_dns_prefix", "com.amazonaws"),
+// 					resource.TestCheckResourceAttr(dataSourceName, "region", endpoints.UsGovWest1RegionID),
+// 					resource.TestCheckResourceAttr(dataSourceName, "reverse_dns_name", fmt.Sprintf("%s.%s.%s", "com.amazonaws", endpoints.UsGovWest1RegionID, waf.EndpointsID)),
+// 					resource.TestCheckResourceAttr(dataSourceName, "service_id", waf.EndpointsID),
+// 					resource.TestCheckResourceAttr(dataSourceName, "supported", "false"),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
+//
+// func testAccCheckServiceConfig_basic() string {
+// 	return fmt.Sprintf(`
+// data "aws_service" "default" {
+//   service_id = %[1]q
+// }
+// `, ec2.EndpointsID)
+// }
+//
+// func testAccCheckServiceConfig_byReverseDNSName() string {
+// 	// lintignore:AWSAT003
+// 	return `
+// data "aws_service" "test" {
+//   reverse_dns_name = "cn.com.amazonaws.cn-north-1.s3"
+// }
+// `
+// }
+//
+// func testAccCheckServiceConfig_byDNSName() string {
+// 	// lintignore:AWSAT003
+// 	return `
+// data "aws_service" "test" {
+//   dns_name = "rds.us-east-1.amazonaws.com"
+// }
+// `
+// }
+//
+// func testAccCheckServiceConfig_byPart() string {
+// 	return `
+// data "aws_region" "current" {}
+//
+// data "aws_service" "test" {
+//   reverse_dns_prefix = "com.amazonaws"
+//   region             = data.aws_region.current.name
+//   service_id         = "s3"
+// }
+// `
+// }
+//
+// func testAccCheckServiceConfig_unsupported() string {
+// 	// lintignore:AWSAT003
+// 	return `
+// data "aws_service" "test" {
+//   reverse_dns_name = "com.amazonaws.us-gov-west-1.waf"
+// }
+// `
+// }

--- a/internal/service/neptune/cluster_endpoint.go
+++ b/internal/service/neptune/cluster_endpoint.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/neptune"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -91,8 +90,7 @@ func resourceClusterEndpointCreate(d *schema.ResourceData, meta interface{}) err
 		input.ExcludedMembers = flex.ExpandStringSet(attr)
 	}
 
-	// Tags are currently only supported in AWS Commercial.
-	if len(tags) > 0 && meta.(*conns.AWSClient).Partition == endpoints.AwsPartitionID {
+	if len(tags) > 0 {
 		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
@@ -140,27 +138,21 @@ func resourceClusterEndpointRead(d *schema.ResourceData, meta interface{}) error
 	arn := aws.StringValue(resp.DBClusterEndpointArn)
 	d.Set("arn", arn)
 
-	// Tags are currently only supported in AWS Commercial.
-	if meta.(*conns.AWSClient).Partition == endpoints.AwsPartitionID {
-		tags, err := ListTags(conn, arn)
+	tags, err := ListTags(conn, arn)
 
-		if err != nil {
-			return fmt.Errorf("error listing tags for Neptune Cluster Endpoint (%s): %w", arn, err)
-		}
+	if err != nil {
+		return fmt.Errorf("error listing tags for Neptune Cluster Endpoint (%s): %w", arn, err)
+	}
 
-		tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
-		//lintignore:AWSR002
-		if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-			return fmt.Errorf("error setting tags: %w", err)
-		}
+	// lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
 
-		if err := d.Set("tags_all", tags.Map()); err != nil {
-			return fmt.Errorf("error setting tags_all: %w", err)
-		}
-	} else {
-		d.Set("tags", nil)
-		d.Set("tags_all", nil)
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return fmt.Errorf("error setting tags_all: %w", err)
 	}
 
 	return nil
@@ -197,8 +189,7 @@ func resourceClusterEndpointUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
-	// Tags are currently only supported in AWS Commercial.
-	if d.HasChange("tags_all") && meta.(*conns.AWSClient).Partition == endpoints.AwsPartitionID {
+	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 
 		if err := UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {

--- a/internal/service/opsworks/stack_test.go
+++ b/internal/service/opsworks/stack_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/opsworks"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -15,9 +14,9 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
-///////////////////////////////
-//// Tests for the No-VPC case
-///////////////////////////////
+// /////////////////////////////
+// // Tests for the No-VPC case
+// /////////////////////////////
 
 func TestAccOpsWorksStack_noVPCBasic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -176,9 +175,9 @@ func TestAccOpsWorksStack_noVPCCreateTags(t *testing.T) {
 	})
 }
 
-/////////////////////////////
+// ///////////////////////////
 // Tests for Custom Cookbooks
-/////////////////////////////
+// ///////////////////////////
 
 func TestAccOpsWorksStack_CustomCookbooks_setPrivateProperties(t *testing.T) {
 	resourceName := "aws_opsworks_stack.test"
@@ -230,7 +229,7 @@ func TestAccOpsWorksStack_classicEndpoints(t *testing.T) {
 	// This test cannot be parallel with other tests, because it changes the provider region in a non-standard way
 	// https://github.com/hashicorp/terraform-provider-aws/issues/21887
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckRegion(t, endpoints.UsWest2RegionID) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, opsworks.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckStackDestroy,
@@ -364,7 +363,7 @@ resource "aws_iam_instance_profile" "opsworks_instance" {
   name = %[1]q
   role = aws_iam_role.opsworks_instance.name
 }
-`, rName) //lintignore:AWSAT003,AT004
+`, rName) // lintignore:AWSAT003,AT004
 }
 
 func testAccStack_regionalEndpoint(rName string) string {
@@ -451,12 +450,12 @@ resource "aws_iam_instance_profile" "opsworks_instance" {
   name = %[1]q
   role = aws_iam_role.opsworks_instance.name
 }
-`, rName) //lintignore:AWSAT003,AT004
+`, rName) // lintignore:AWSAT003,AT004
 }
 
-////////////////////////////
-//// Checkers and Utilities
-////////////////////////////
+// //////////////////////////
+// // Checkers and Utilities
+// //////////////////////////
 
 func testAccCheckCreateStackAttributes(rName string) resource.TestCheckFunc {
 	resourceName := "aws_opsworks_stack.test"
@@ -539,9 +538,9 @@ func testAccCheckStackDestroy(s *terraform.State) error {
 	return nil
 }
 
-//////////////////////////////////////////////////
-//// Helper configs for the necessary IAM objects
-//////////////////////////////////////////////////
+// ////////////////////////////////////////////////
+// // Helper configs for the necessary IAM objects
+// ////////////////////////////////////////////////
 
 func testAccStackNoVPCCreateConfig(rName string) string {
 	return acctest.ConfigCompose(
@@ -992,9 +991,9 @@ resource "aws_iam_instance_profile" "opsworks_instance" {
 `, rName))
 }
 
-////////////////////////////
-//// Tests for the VPC case
-////////////////////////////
+// //////////////////////////
+// // Tests for the VPC case
+// //////////////////////////
 
 func testAccStackVPCCreateConfig(rName string) string {
 	return acctest.ConfigCompose(
@@ -1241,9 +1240,9 @@ resource "aws_iam_instance_profile" "opsworks_instance" {
 `, rName))
 }
 
-/////////////////////////////////////////
+// ///////////////////////////////////////
 // Helpers for Custom Cookbook properties
-/////////////////////////////////////////
+// ///////////////////////////////////////
 
 func testAccStackConfig_CustomCookbooks_Set(rName string) string {
 	return acctest.ConfigCompose(

--- a/internal/service/paas/consts.go
+++ b/internal/service/paas/consts.go
@@ -15,7 +15,7 @@ const (
 )
 
 const (
-	ServiceNotFoundCode = "Document.NotFound"
+	ServiceNotFoundCode = "PaasServiceNotFound"
 )
 
 const (

--- a/internal/service/paas/service_test.go
+++ b/internal/service/paas/service_test.go
@@ -66,7 +66,7 @@ func TestAccPaaSServiceElasticSearch_basic(t *testing.T) {
 						"kibana":       "false",
 						"logging.#":    "0",
 						"monitoring.#": "0",
-						"version":      "8.12",
+						"version":      "8.17",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "endpoints.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "environment_version"),
@@ -167,6 +167,20 @@ resource "aws_vpc" "test" {
   }
 }
 
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name  = %[1]q
+  }
+}
+
+resource "aws_route" "test" {
+  route_table_id         = aws_vpc.test.main_route_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.test.id
+}
+
 resource "aws_subnet" "test" {
   cidr_block = "10.0.1.0/24"
   vpc_id     = aws_vpc.test.id
@@ -177,12 +191,14 @@ resource "aws_subnet" "test" {
 }
 
 resource "aws_key_pair" "test" {
-  key_name   = %[1]q
-  public_key = %[2]q
+  key_name   = %[2]q
+  public_key = %[3]q
 }
 
 resource "aws_paas_service" "test" {
-  name          = %[3]q 
+  depends_on = ["aws_internet_gateway.test"]
+
+  name          = %[1]q
   instance_type = "c5.large"
 
   root_volume {
@@ -200,8 +216,8 @@ resource "aws_paas_service" "test" {
   ssh_key_name = aws_key_pair.test.key_name
 
   elasticsearch {
-    version = "8.12"
+    version = "8.17"
   }
 }
-`, keyName, publicKey, serviceName)
+`, serviceName, keyName, publicKey)
 }

--- a/internal/service/rds/cluster_activity_stream_test.go
+++ b/internal/service/rds/cluster_activity_stream_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/rds"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -27,10 +26,7 @@ func TestAccRDSClusterActivityStream_basic(t *testing.T) {
 	kmsKeyResourceName := "aws_kms_key.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(t)
-			acctest.PreCheckPartition(t, endpoints.AwsPartitionID)
-		},
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, rds.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckClusterActivityStreamDestroy,
@@ -64,10 +60,7 @@ func TestAccRDSClusterActivityStream_disappears(t *testing.T) {
 	resourceName := "aws_rds_cluster_activity_stream.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(t)
-			acctest.PreCheckPartition(t, endpoints.AwsPartitionID)
-		},
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, rds.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckClusterActivityStreamDestroy,

--- a/internal/service/redshift/service_account_data_source.go
+++ b/internal/service/redshift/service_account_data_source.go
@@ -4,41 +4,16 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
+// FIXME: get rid of `ServiceAccountPerRegionMap` and probably of this resource.
+
 // See http://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html#db-auditing-bucket-permissions
 // See https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-redshift.html
 // See https://docs.amazonaws.cn/en_us/redshift/latest/mgmt/db-auditing.html#db-auditing-bucket-permissions
-var ServiceAccountPerRegionMap = map[string]string{
-	endpoints.AfSouth1RegionID:     "365689465814",
-	endpoints.ApEast1RegionID:      "313564881002",
-	endpoints.ApNortheast1RegionID: "404641285394",
-	endpoints.ApNortheast2RegionID: "760740231472",
-	endpoints.ApNortheast3RegionID: "090321488786",
-	endpoints.ApSouth1RegionID:     "865932855811",
-	endpoints.ApSoutheast1RegionID: "361669875840",
-	endpoints.ApSoutheast2RegionID: "762762565011",
-	endpoints.CaCentral1RegionID:   "907379612154",
-	endpoints.CnNorth1RegionID:     "111890595117",
-	endpoints.CnNorthwest1RegionID: "660998842044",
-	endpoints.EuCentral1RegionID:   "053454850223",
-	endpoints.EuNorth1RegionID:     "729911121831",
-	endpoints.EuSouth1RegionID:     "945612479654",
-	endpoints.EuWest1RegionID:      "210876761215",
-	endpoints.EuWest2RegionID:      "307160386991",
-	endpoints.EuWest3RegionID:      "915173422425",
-	endpoints.MeSouth1RegionID:     "013126148197",
-	endpoints.SaEast1RegionID:      "075028567923",
-	endpoints.UsEast1RegionID:      "193672423079",
-	endpoints.UsEast2RegionID:      "391106570357",
-	endpoints.UsGovEast1RegionID:   "665727464434",
-	endpoints.UsGovWest1RegionID:   "665727464434",
-	endpoints.UsWest1RegionID:      "262260360010",
-	endpoints.UsWest2RegionID:      "902366379725",
-}
+var ServiceAccountPerRegionMap = map[string]string{}
 
 func DataSourceServiceAccount() *schema.Resource {
 	return &schema.Resource{

--- a/internal/service/route53/health_check.go
+++ b/internal/service/route53/health_check.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -151,19 +150,7 @@ func ResourceHealthCheck() *schema.Resource {
 				Type:     schema.TypeSet,
 				MinItems: 3,
 				MaxItems: 64,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-					ValidateFunc: validation.StringInSlice([]string{
-						endpoints.UsWest1RegionID,
-						endpoints.UsWest2RegionID,
-						endpoints.UsEast1RegionID,
-						endpoints.EuWest1RegionID,
-						endpoints.SaEast1RegionID,
-						endpoints.ApSoutheast1RegionID,
-						endpoints.ApSoutheast2RegionID,
-						endpoints.ApNortheast1RegionID,
-					}, true),
-				},
+				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
 			},
 
@@ -357,7 +344,7 @@ func resourceHealthCheckRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
-	//lintignore:AWSR002
+	// lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %w", err)
 	}

--- a/internal/service/route53/health_check_test.go
+++ b/internal/service/route53/health_check_test.go
@@ -167,7 +167,7 @@ func TestAccRoute53HealthCheck_withHealthCheckRegions(t *testing.T) {
 		CheckDestroy:      testAccCheckHealthCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHealthCheckConfig_regions(endpoints.UsWest2RegionID, endpoints.UsEast1RegionID, endpoints.EuWest1RegionID),
+				Config: testAccHealthCheckConfig_regions(endpoints.RuMskRegionID, endpoints.RuSpbRegionID),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHealthCheckExists(resourceName, &check),
 					resource.TestCheckResourceAttr(resourceName, "regions.#", "3"),

--- a/internal/service/route53/health_check_test.go
+++ b/internal/service/route53/health_check_test.go
@@ -161,7 +161,7 @@ func TestAccRoute53HealthCheck_withHealthCheckRegions(t *testing.T) {
 	var check route53.HealthCheck
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckPartition(t, endpoints.AwsPartitionID) }, // GovCloud has 2 regions, test requires 3
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, route53.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckHealthCheckDestroy,

--- a/internal/service/route53/key_signing_key_test.go
+++ b/internal/service/route53/key_signing_key_test.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -314,19 +313,9 @@ func testAccKeySigningKeyRegionProviderConfig() string {
 	return acctest.ConfigRegionalProvider(testAccGetKeySigningKeyRegion())
 }
 
+// FIXME: testAccRoute53KeySigningKeyRegion is always "". Fix it, if Route53 KSK is supported.
+
 // testAccGetKeySigningKeyRegion returns the Route 53 Key Signing Key region for testing
 func testAccGetKeySigningKeyRegion() string {
-	if testAccRoute53KeySigningKeyRegion != "" {
-		return testAccRoute53KeySigningKeyRegion
-	}
-
-	// AWS Commercial: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-configuring-dnssec-cmk-requirements.html
-	// AWS GovCloud (US) - not available yet: https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-r53.html
-	// AWS China - not available yet: https://docs.amazonaws.cn/en_us/aws/latest/userguide/route53.html
-	switch acctest.Partition() {
-	case endpoints.AwsPartitionID:
-		testAccRoute53KeySigningKeyRegion = endpoints.UsEast1RegionID
-	}
-
 	return testAccRoute53KeySigningKeyRegion
 }

--- a/internal/service/route53/query_log_test.go
+++ b/internal/service/route53/query_log_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -264,19 +263,9 @@ func testAccQueryLogRegionProviderConfig() string {
 	return acctest.ConfigRegionalProvider(testAccGetQueryLogRegion())
 }
 
+// FIXME: testAccRoute53QueryLogRegion is always "". Fix it, if Route53 Query Logging is supported.
+
 // testAccGetQueryLogRegion returns the Route 53 Query Logging region for testing
 func testAccGetQueryLogRegion() string {
-	if testAccRoute53QueryLogRegion != "" {
-		return testAccRoute53QueryLogRegion
-	}
-
-	// AWS Commercial: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/query-logs.html
-	// AWS GovCloud (US) - only private DNS: https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-r53.html
-	// AWS China - not available yet: https://docs.amazonaws.cn/en_us/aws/latest/userguide/route53.html
-	switch acctest.Partition() {
-	case endpoints.AwsPartitionID:
-		testAccRoute53QueryLogRegion = endpoints.UsEast1RegionID
-	}
-
 	return testAccRoute53QueryLogRegion
 }

--- a/internal/service/route53/record_test.go
+++ b/internal/service/route53/record_test.go
@@ -797,7 +797,7 @@ func TestAccRoute53Record_Latency_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRecordConfig_latencyCNAME(endpoints.UsEast1RegionID, endpoints.EuWest1RegionID, endpoints.ApNortheast1RegionID),
+				Config: testAccRecordConfig_latencyCNAME(endpoints.RuMskRegionID, endpoints.RuSpbRegionID, endpoints.RuSpbRegionID),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(resourceName, &record1),
 					testAccCheckRecordExists("aws_route53_record.second_region", &record2),

--- a/internal/service/route53/traffic_policy_instance_test.go
+++ b/internal/service/route53/traffic_policy_instance_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/route53"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -18,10 +17,6 @@ import (
 
 func testAccPreCheckTrafficPolicy(t *testing.T) {
 	acctest.PreCheckPartitionHasService(route53.EndpointsID, t)
-
-	if got, want := acctest.Partition(), endpoints.AwsUsGovPartitionID; got == want {
-		t.Skipf("Route 53 Traffic Policies are not supported in %s partition", got)
-	}
 }
 
 func TestAccRoute53TrafficPolicyInstance_basic(t *testing.T) {

--- a/internal/service/route53recoveryreadiness/readiness_check_test.go
+++ b/internal/service/route53recoveryreadiness/readiness_check_test.go
@@ -23,8 +23,8 @@ func TestAccRoute53RecoveryReadinessReadinessCheck_basic(t *testing.T) {
 	resourceName := "aws_route53recoveryreadiness_readiness_check.test"
 	cwArn := arn.ARN{
 		AccountID: "123456789012",
-		Partition: endpoints.AwsPartitionID,
-		Region:    endpoints.EuWest1RegionID,
+		Partition: "c2",
+		Region:    endpoints.RuMskRegionID,
 		Resource:  "alarm:zzzzzzzzz",
 		Service:   "cloudwatch",
 	}.String()
@@ -58,8 +58,8 @@ func TestAccRoute53RecoveryReadinessReadinessCheck_disappears(t *testing.T) {
 	resourceName := "aws_route53recoveryreadiness_readiness_check.test"
 	cwArn := arn.ARN{
 		AccountID: "123456789012",
-		Partition: endpoints.AwsPartitionID,
-		Region:    endpoints.EuWest1RegionID,
+		Partition: "c2",
+		Region:    endpoints.RuMskRegionID,
 		Resource:  "alarm:zzzzzzzzz",
 		Service:   "cloudwatch",
 	}.String()
@@ -87,8 +87,8 @@ func TestAccRoute53RecoveryReadinessReadinessCheck_tags(t *testing.T) {
 	resourceName := "aws_route53recoveryreadiness_readiness_check.test"
 	cwArn := arn.ARN{
 		AccountID: "123456789012",
-		Partition: endpoints.AwsPartitionID,
-		Region:    endpoints.EuWest1RegionID,
+		Partition: "c2",
+		Region:    endpoints.RuMskRegionID,
 		Resource:  "alarm:zzzzzzzzz",
 		Service:   "cloudwatch",
 	}.String()
@@ -139,8 +139,8 @@ func TestAccRoute53RecoveryReadinessReadinessCheck_timeout(t *testing.T) {
 	resourceName := "aws_route53recoveryreadiness_readiness_check.test"
 	cwArn := arn.ARN{
 		AccountID: "123456789012",
-		Partition: endpoints.AwsPartitionID,
-		Region:    endpoints.EuWest1RegionID,
+		Partition: "c2",
+		Region:    endpoints.RuMskRegionID,
 		Resource:  "alarm:zzzzzzzzz",
 		Service:   "cloudwatch",
 	}.String()

--- a/internal/service/route53recoveryreadiness/resource_set_test.go
+++ b/internal/service/route53recoveryreadiness/resource_set_test.go
@@ -21,8 +21,8 @@ func TestAccRoute53RecoveryReadinessResourceSet_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	cwArn := arn.ARN{
 		AccountID: "123456789012",
-		Partition: endpoints.AwsPartitionID,
-		Region:    endpoints.EuWest1RegionID,
+		Partition: "c2",
+		Region:    endpoints.RuMskRegionID,
 		Resource:  "alarm:zzzzzzzzz",
 		Service:   "cloudwatch",
 	}.String()
@@ -56,8 +56,8 @@ func TestAccRoute53RecoveryReadinessResourceSet_disappears(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	cwArn := arn.ARN{
 		AccountID: "123456789012",
-		Partition: endpoints.AwsPartitionID,
-		Region:    endpoints.EuWest1RegionID,
+		Partition: "c2",
+		Region:    endpoints.RuMskRegionID,
 		Resource:  "alarm:zzzzzzzzz",
 		Service:   "cloudwatch",
 	}.String()
@@ -86,8 +86,8 @@ func TestAccRoute53RecoveryReadinessResourceSet_tags(t *testing.T) {
 	resourceName := "aws_route53recoveryreadiness_resource_set.test"
 	cwArn := arn.ARN{
 		AccountID: "123456789012",
-		Partition: endpoints.AwsPartitionID,
-		Region:    endpoints.EuWest1RegionID,
+		Partition: "c2",
+		Region:    endpoints.RuMskRegionID,
 		Resource:  "alarm:zzzzzzzzz",
 		Service:   "cloudwatch",
 	}.String()
@@ -137,8 +137,8 @@ func TestAccRoute53RecoveryReadinessResourceSet_readinessScope(t *testing.T) {
 	resourceName := "aws_route53recoveryreadiness_resource_set.test"
 	cwArn := arn.ARN{
 		AccountID: "123456789012",
-		Partition: endpoints.AwsPartitionID,
-		Region:    endpoints.EuWest1RegionID,
+		Partition: "c2",
+		Region:    endpoints.RuMskRegionID,
 		Resource:  "alarm:zzzzzzzzz",
 		Service:   "cloudwatch",
 	}.String()
@@ -172,8 +172,8 @@ func TestAccRoute53RecoveryReadinessResourceSet_basicDNSTargetResource(t *testin
 	domainName := "myTestDomain.test"
 	hzArn := arn.ARN{
 		AccountID: "123456789012",
-		Partition: endpoints.AwsPartitionID,
-		Region:    endpoints.EuWest1RegionID,
+		Partition: "c2",
+		Region:    endpoints.RuMskRegionID,
 		Resource:  "hostedzone/zzzzzzzzz",
 		Service:   "route53",
 	}.String()
@@ -214,8 +214,8 @@ func TestAccRoute53RecoveryReadinessResourceSet_dnsTargetResourceNLBTarget(t *te
 	resourceName := "aws_route53recoveryreadiness_resource_set.test"
 	hzArn := arn.ARN{
 		AccountID: "123456789012",
-		Partition: endpoints.AwsPartitionID,
-		Region:    endpoints.EuWest1RegionID,
+		Partition: "c2",
+		Region:    endpoints.RuMskRegionID,
 		Resource:  "hostedzone/zzzzzzzzz",
 		Service:   "route53",
 	}.String()
@@ -251,8 +251,8 @@ func TestAccRoute53RecoveryReadinessResourceSet_dnsTargetResourceR53Target(t *te
 	resourceName := "aws_route53recoveryreadiness_resource_set.test"
 	hzArn := arn.ARN{
 		AccountID: "123456789012",
-		Partition: endpoints.AwsPartitionID,
-		Region:    endpoints.EuWest1RegionID,
+		Partition: "c2",
+		Region:    endpoints.RuMskRegionID,
 		Resource:  "hostedzone/zzzzzzzzz",
 		Service:   "route53",
 	}.String()
@@ -290,8 +290,8 @@ func TestAccRoute53RecoveryReadinessResourceSet_timeout(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	cwArn := arn.ARN{
 		AccountID: "123456789012",
-		Partition: endpoints.AwsPartitionID,
-		Region:    endpoints.EuWest1RegionID,
+		Partition: "c2",
+		Region:    endpoints.RuMskRegionID,
 		Resource:  "alarm:zzzzzzzzz",
 		Service:   "cloudwatch",
 	}.String()

--- a/internal/service/s3/acc_test.go
+++ b/internal/service/s3/acc_test.go
@@ -3,15 +3,12 @@ package s3_test
 import (
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	tfs3 "github.com/hashicorp/terraform-provider-aws/internal/service/s3"
 )
 
 func TestHostedZoneIDForRegion(t *testing.T) {
-	if r, _ := tfs3.HostedZoneIDForRegion(endpoints.UsEast1RegionID); r != "Z3AQBSTGFYJSTF" {
-		t.Fatalf("bad: %s", r)
-	}
-	if r, _ := tfs3.HostedZoneIDForRegion(endpoints.ApSoutheast2RegionID); r != "Z1WCIGYICN2BYD" {
+	// lintignore:AWSAT003
+	if r, _ := tfs3.HostedZoneIDForRegion("us-east-1"); r != "Z3AQBSTGFYJSTF" {
 		t.Fatalf("bad: %s", r)
 	}
 

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -731,14 +731,6 @@ func resourceBucketCreate(d *schema.ResourceData, meta interface{}) error {
 	awsRegion := meta.(*conns.AWSClient).Region
 	log.Printf("[DEBUG] S3 bucket create: %s, using region: %s", bucket, awsRegion)
 
-	// Special case us-east-1 region and do not set the LocationConstraint.
-	// See "Request Elements: http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUT.html
-	if awsRegion != endpoints.UsEast1RegionID {
-		req.CreateBucketConfiguration = &s3.CreateBucketConfiguration{
-			LocationConstraint: aws.String(awsRegion),
-		}
-	}
-
 	if err := ValidBucketName(bucket, awsRegion); err != nil {
 		return fmt.Errorf("error validating S3 Bucket (%s) name: %w", bucket, err)
 	}

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -1378,7 +1378,7 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
-	//lintignore:AWSR002
+	// lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %w", err)
 	}
@@ -1450,7 +1450,7 @@ func BucketRegionalDomainName(bucket string, region string) (string, error) {
 	// Return a default AWS Commercial domain name if no region is provided
 	// Otherwise EndpointFor() will return BUCKET.s3..amazonaws.com
 	if region == "" {
-		return fmt.Sprintf("%s.s3.amazonaws.com", bucket), nil //lintignore:AWSR001
+		return fmt.Sprintf("%s.s3.amazonaws.com", bucket), nil // lintignore:AWSR001
 	}
 	endpoint, err := endpoints.DefaultResolver().EndpointFor(endpoints.S3ServiceID, region)
 	if err != nil {
@@ -1475,7 +1475,7 @@ func WebsiteDomainUrl(client *conns.AWSClient, region string) string {
 	// https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteEndpoints.html
 	// https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints
 	if isOldRegion(region) {
-		return fmt.Sprintf("s3-website-%s.amazonaws.com", region) //lintignore:AWSR001
+		return fmt.Sprintf("s3-website-%s.amazonaws.com", region) // lintignore:AWSR001
 	}
 	return client.RegionalHostname("s3-website")
 }
@@ -1510,17 +1510,12 @@ func websiteEndpoint(client *conns.AWSClient, d *schema.ResourceData) (*S3Websit
 	return WebsiteEndpoint(client, bucket, region), nil
 }
 
+// FIXME: get rid of using aws regions when fixing bucket attributes:
+//  bucket_domain_name, region, bucket_regional_domain_name, website_endpoint, website_domain.
+
 func isOldRegion(region string) bool {
 	oldRegions := []string{
-		endpoints.ApNortheast1RegionID,
-		endpoints.ApSoutheast1RegionID,
-		endpoints.ApSoutheast2RegionID,
-		endpoints.EuWest1RegionID,
-		endpoints.SaEast1RegionID,
-		endpoints.UsEast1RegionID,
-		endpoints.UsGovWest1RegionID,
-		endpoints.UsWest1RegionID,
-		endpoints.UsWest2RegionID,
+		"us-east-1", // lintignore:AWSAT003
 	}
 	for _, r := range oldRegions {
 		if region == r {
@@ -1534,13 +1529,13 @@ func normalizeRegion(region string) string {
 	// Default to us-east-1 if the bucket doesn't have a region:
 	// http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlocation.html
 	if region == "" {
-		region = endpoints.UsEast1RegionID
+		region = "us-east-1" // lintignore:AWSAT003
 	}
 
 	return region
 }
 
-////////////////////////////////////////// Argument-Specific Update Functions //////////////////////////////////////////
+// //////////////////////////////////////// Argument-Specific Update Functions //////////////////////////////////////////
 
 func resourceBucketInternalAccelerationUpdate(conn *s3.S3, d *schema.ResourceData) error {
 	input := &s3.PutBucketAccelerateConfigurationInput{
@@ -2117,7 +2112,7 @@ func resourceBucketInternalWebsiteUpdate(conn *s3.S3, d *schema.ResourceData) er
 	return err
 }
 
-///////////////////////////////////////////// Expand and Flatten functions /////////////////////////////////////////////
+// /////////////////////////////////////////// Expand and Flatten functions /////////////////////////////////////////////
 
 // Cors Rule functions
 

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -728,10 +728,7 @@ func resourceBucketCreate(d *schema.ResourceData, meta interface{}) error {
 		log.Printf("[DEBUG] S3 bucket %s has default canned ACL %s", bucket, s3.BucketCannedACLPrivate)
 	}
 
-	awsRegion := meta.(*conns.AWSClient).Region
-	log.Printf("[DEBUG] S3 bucket create: %s, using region: %s", bucket, awsRegion)
-
-	if err := ValidBucketName(bucket, awsRegion); err != nil {
+	if err := ValidBucketName(bucket); err != nil {
 		return fmt.Errorf("error validating S3 Bucket (%s) name: %w", bucket, err)
 	}
 

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -1259,9 +1259,7 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 
 	// Object lock not supported in all partitions (extra guard, also guards in read func)
 	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeMethodNotAllowed, ErrCodeNotImplemented, ErrCodeObjectLockConfigurationNotFound) {
-		if meta.(*conns.AWSClient).Partition == endpoints.AwsPartitionID || meta.(*conns.AWSClient).Partition == endpoints.AwsUsGovPartitionID {
-			return fmt.Errorf("error getting S3 Bucket (%s) Object Lock configuration: %w", d.Id(), err)
-		}
+		return fmt.Errorf("error getting S3 Bucket (%s) Object Lock configuration: %w", d.Id(), err)
 	}
 
 	if err != nil {

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -2362,7 +2362,7 @@ func TestBucketName(t *testing.T) {
 	}
 
 	for _, v := range validDnsNames {
-		if err := tfs3.ValidBucketName(v, endpoints.UsWest2RegionID); err != nil {
+		if err := tfs3.ValidBucketName(v); err != nil {
 			t.Fatalf("%q should be a valid S3 bucket name", v)
 		}
 	}
@@ -2379,35 +2379,7 @@ func TestBucketName(t *testing.T) {
 	}
 
 	for _, v := range invalidDnsNames {
-		if err := tfs3.ValidBucketName(v, endpoints.UsWest2RegionID); err == nil {
-			t.Fatalf("%q should not be a valid S3 bucket name", v)
-		}
-	}
-
-	validEastNames := []string{
-		"foobar",
-		"foo_bar",
-		"127.0.0.1",
-		"foo..bar",
-		"foo_bar_baz",
-		"foo.bar.baz",
-		"Foo.Bar",
-		strings.Repeat("x", 255),
-	}
-
-	for _, v := range validEastNames {
-		if err := tfs3.ValidBucketName(v, endpoints.UsEast1RegionID); err != nil {
-			t.Fatalf("%q should be a valid S3 bucket name", v)
-		}
-	}
-
-	invalidEastNames := []string{
-		"foo;bar",
-		strings.Repeat("x", 256),
-	}
-
-	for _, v := range invalidEastNames {
-		if err := tfs3.ValidBucketName(v, endpoints.UsEast1RegionID); err == nil {
+		if err := tfs3.ValidBucketName(v); err == nil {
 			t.Fatalf("%q should not be a valid S3 bucket name", v)
 		}
 	}
@@ -2427,34 +2399,27 @@ func TestBucketRegionalDomainName(t *testing.T) {
 			ExpectedOutput:   bucket + ".s3.amazonaws.com",
 		},
 		{
-			Region:           "custom",
+			Region:           "custom-region",
 			ExpectedErrCount: 0,
-			ExpectedOutput:   bucket + ".s3.custom.amazonaws.com",
+			ExpectedOutput: bucket + fmt.Sprintf(
+				".s3.custom-region.%s",
+				endpoints.K2Partition().DNSSuffix(),
+			),
 		},
 		{
-			Region:           endpoints.UsEast1RegionID,
+			Region:           endpoints.RuMskRegionID,
 			ExpectedErrCount: 0,
-			ExpectedOutput:   bucket + ".s3.amazonaws.com",
-		},
-		{
-			Region:           endpoints.UsWest2RegionID,
-			ExpectedErrCount: 0,
-			ExpectedOutput:   bucket + fmt.Sprintf(".s3.%s.%s", endpoints.UsWest2RegionID, acctest.PartitionDNSSuffix()),
-		},
-		{
-			Region:           endpoints.UsGovWest1RegionID,
-			ExpectedErrCount: 0,
-			ExpectedOutput:   bucket + fmt.Sprintf(".s3.%s.%s", endpoints.UsGovWest1RegionID, acctest.PartitionDNSSuffix()),
-		},
-		{
-			Region:           endpoints.CnNorth1RegionID,
-			ExpectedErrCount: 0,
-			ExpectedOutput:   bucket + fmt.Sprintf(".s3.%s.amazonaws.com.cn", endpoints.CnNorth1RegionID),
+			ExpectedOutput: bucket + fmt.Sprintf(
+				".s3.%s.%s",
+				endpoints.RuMskRegionID,
+				endpoints.K2Partition().DNSSuffix(),
+			),
 		},
 	}
 
 	for _, tc := range testCases {
 		output, err := tfs3.BucketRegionalDomainName(bucket, tc.Region)
+
 		if tc.ExpectedErrCount == 0 && err != nil {
 			t.Fatalf("expected %q not to trigger an error, received: %s", tc.Region, err)
 		}
@@ -2468,7 +2433,6 @@ func TestBucketRegionalDomainName(t *testing.T) {
 }
 
 func TestWebsiteEndpoint(t *testing.T) {
-	// https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteEndpoints.html
 	testCases := []struct {
 		TestingClient      *conns.AWSClient
 		LocationConstraint string
@@ -2477,146 +2441,18 @@ func TestWebsiteEndpoint(t *testing.T) {
 		{
 			TestingClient: &conns.AWSClient{
 				DNSSuffix: "amazonaws.com",
-				Region:    endpoints.UsEast1RegionID,
+				Region:    "us-east-1", // lintignore:AWSAT003
 			},
 			LocationConstraint: "",
-			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.%s", endpoints.UsEast1RegionID, acctest.PartitionDNSSuffix()),
+			Expected:           "bucket-name.s3-website-us-east-1.amazonaws.com", // lintignore:AWSAT003
 		},
 		{
 			TestingClient: &conns.AWSClient{
-				DNSSuffix: "amazonaws.com",
-				Region:    endpoints.UsWest2RegionID,
+				DNSSuffix: "custom.suffix",
+				Region:    "custom-region",
 			},
-			LocationConstraint: endpoints.UsWest2RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.%s", endpoints.UsWest2RegionID, acctest.PartitionDNSSuffix()),
-		},
-		{
-			TestingClient: &conns.AWSClient{
-				DNSSuffix: "amazonaws.com",
-				Region:    endpoints.UsWest1RegionID,
-			},
-			LocationConstraint: endpoints.UsWest1RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.%s", endpoints.UsWest1RegionID, acctest.PartitionDNSSuffix()),
-		},
-		{
-			TestingClient: &conns.AWSClient{
-				DNSSuffix: "amazonaws.com",
-				Region:    endpoints.EuWest1RegionID,
-			},
-			LocationConstraint: endpoints.EuWest1RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.%s", endpoints.EuWest1RegionID, acctest.PartitionDNSSuffix()),
-		},
-		{
-			TestingClient: &conns.AWSClient{
-				DNSSuffix: "amazonaws.com",
-				Region:    endpoints.EuWest3RegionID,
-			},
-			LocationConstraint: endpoints.EuWest3RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website.%s.%s", endpoints.EuWest3RegionID, acctest.PartitionDNSSuffix()),
-		},
-		{
-			TestingClient: &conns.AWSClient{
-				DNSSuffix: "amazonaws.com",
-				Region:    endpoints.EuCentral1RegionID,
-			},
-			LocationConstraint: endpoints.EuCentral1RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website.%s.%s", endpoints.EuCentral1RegionID, acctest.PartitionDNSSuffix()),
-		},
-		{
-			TestingClient: &conns.AWSClient{
-				DNSSuffix: "amazonaws.com",
-				Region:    endpoints.ApSouth1RegionID,
-			},
-			LocationConstraint: endpoints.ApSouth1RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website.%s.%s", endpoints.ApSouth1RegionID, acctest.PartitionDNSSuffix()),
-		},
-		{
-			TestingClient: &conns.AWSClient{
-				DNSSuffix: "amazonaws.com",
-				Region:    endpoints.ApSoutheast1RegionID,
-			},
-			LocationConstraint: endpoints.ApSoutheast1RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.%s", endpoints.ApSoutheast1RegionID, acctest.PartitionDNSSuffix()),
-		},
-		{
-			TestingClient: &conns.AWSClient{
-				DNSSuffix: "amazonaws.com",
-				Region:    endpoints.ApNortheast1RegionID,
-			},
-			LocationConstraint: endpoints.ApNortheast1RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.%s", endpoints.ApNortheast1RegionID, acctest.PartitionDNSSuffix()),
-		},
-		{
-			TestingClient: &conns.AWSClient{
-				DNSSuffix: "amazonaws.com",
-				Region:    endpoints.ApSoutheast2RegionID,
-			},
-			LocationConstraint: endpoints.ApSoutheast2RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.%s", endpoints.ApSoutheast2RegionID, acctest.PartitionDNSSuffix()),
-		},
-		{
-			TestingClient: &conns.AWSClient{
-				DNSSuffix: "amazonaws.com",
-				Region:    endpoints.ApNortheast2RegionID,
-			},
-			LocationConstraint: endpoints.ApNortheast2RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website.%s.%s", endpoints.ApNortheast2RegionID, acctest.PartitionDNSSuffix()),
-		},
-		{
-			TestingClient: &conns.AWSClient{
-				DNSSuffix: "amazonaws.com",
-				Region:    endpoints.SaEast1RegionID,
-			},
-			LocationConstraint: endpoints.SaEast1RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.%s", endpoints.SaEast1RegionID, acctest.PartitionDNSSuffix()),
-		},
-		{
-			TestingClient: &conns.AWSClient{
-				DNSSuffix: "amazonaws.com",
-				Region:    endpoints.UsGovEast1RegionID,
-			},
-			LocationConstraint: endpoints.UsGovEast1RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website.%s.%s", endpoints.UsGovEast1RegionID, acctest.PartitionDNSSuffix()),
-		},
-		{
-			TestingClient: &conns.AWSClient{
-				DNSSuffix: "amazonaws.com",
-				Region:    endpoints.UsGovWest1RegionID,
-			},
-			LocationConstraint: endpoints.UsGovWest1RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.%s", endpoints.UsGovWest1RegionID, acctest.PartitionDNSSuffix()),
-		},
-		{
-			TestingClient: &conns.AWSClient{
-				DNSSuffix: "c2s.ic.gov",
-				Region:    endpoints.UsIsoEast1RegionID,
-			},
-			LocationConstraint: endpoints.UsIsoEast1RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website.%s.c2s.ic.gov", endpoints.UsIsoEast1RegionID),
-		},
-		{
-			TestingClient: &conns.AWSClient{
-				DNSSuffix: "sc2s.sgov.gov",
-				Region:    endpoints.UsIsobEast1RegionID,
-			},
-			LocationConstraint: endpoints.UsIsobEast1RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website.%s.sc2s.sgov.gov", endpoints.UsIsobEast1RegionID),
-		},
-		{
-			TestingClient: &conns.AWSClient{
-				DNSSuffix: "amazonaws.com.cn",
-				Region:    endpoints.CnNorthwest1RegionID,
-			},
-			LocationConstraint: endpoints.CnNorthwest1RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website.%s.amazonaws.com.cn", endpoints.CnNorthwest1RegionID),
-		},
-		{
-			TestingClient: &conns.AWSClient{
-				DNSSuffix: "amazonaws.com.cn",
-				Region:    endpoints.CnNorth1RegionID,
-			},
-			LocationConstraint: endpoints.CnNorth1RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website.%s.amazonaws.com.cn", endpoints.CnNorth1RegionID),
+			LocationConstraint: "custom-region",
+			Expected:           "bucket-name.s3-website.custom-region.custom.suffix",
 		},
 	}
 

--- a/internal/service/s3/hosted_zones.go
+++ b/internal/service/s3/hosted_zones.go
@@ -2,37 +2,14 @@ package s3
 
 import (
 	"fmt"
-
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 )
+
+// FIXME: get rid of using aws regions when fixing hosted_zone_id for a bucket.
 
 // See https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_website_region_endpoints.
 var hostedZoneIDsMap = map[string]string{
-	endpoints.AfSouth1RegionID:     "Z83WF9RJE8B12",
-	endpoints.ApEast1RegionID:      "ZNB98KWMFR0R6",
-	endpoints.ApNortheast1RegionID: "Z2M4EHUR26P7ZW",
-	endpoints.ApNortheast2RegionID: "Z3W03O7B5YMIYP",
-	endpoints.ApNortheast3RegionID: "Z2YQB5RD63NC85",
-	endpoints.ApSouth1RegionID:     "Z11RGJOFQNVJUP",
-	endpoints.ApSoutheast1RegionID: "Z3O0J2DXBE1FTB",
-	endpoints.ApSoutheast2RegionID: "Z1WCIGYICN2BYD",
-	endpoints.ApSoutheast3RegionID: "Z01613992JD795ZI93075",
-	endpoints.CaCentral1RegionID:   "Z1QDHH18159H29",
-	endpoints.CnNorthwest1RegionID: "Z282HJ1KT0DH03",
-	endpoints.EuCentral1RegionID:   "Z21DNDUVLTQW6Q",
-	endpoints.EuNorth1RegionID:     "Z3BAZG2TWCNX0D",
-	endpoints.EuSouth1RegionID:     "Z30OZKI7KPW7MI",
-	endpoints.EuWest1RegionID:      "Z1BKCTXD74EZPE",
-	endpoints.EuWest2RegionID:      "Z3GKZC51ZF0DB4",
-	endpoints.EuWest3RegionID:      "Z3R1K369G5AVDG",
-	endpoints.MeSouth1RegionID:     "Z1MPMWCPA7YB62",
-	endpoints.SaEast1RegionID:      "Z7KQH4QJS55SO",
-	endpoints.UsEast1RegionID:      "Z3AQBSTGFYJSTF",
-	endpoints.UsEast2RegionID:      "Z2O1EMRO9K5GLX",
-	endpoints.UsGovEast1RegionID:   "Z2NIFVYYW2VKV1",
-	endpoints.UsGovWest1RegionID:   "Z31GFT0UA1I2HV",
-	endpoints.UsWest1RegionID:      "Z2F56UZL2M1ACD",
-	endpoints.UsWest2RegionID:      "Z3BJ6K6RIION7M",
+	// lintignore:AWSAT003
+	"us-east-1": "Z3AQBSTGFYJSTF",
 }
 
 // Returns the hosted zone ID for an S3 website endpoint region. This can be

--- a/internal/service/s3/validate.go
+++ b/internal/service/s3/validate.go
@@ -5,41 +5,30 @@ import (
 	"regexp"
 	"strings"
 	"time"
-
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 )
 
-// ValidBucketName validates any S3 bucket name that is not inside the us-east-1 region.
-// Buckets outside of this region have to be DNS-compliant. After the same restrictions are
-// applied to buckets in the us-east-1 region, this function can be refactored as a SchemaValidateFunc
-func ValidBucketName(value string, region string) error {
-	if region != endpoints.UsEast1RegionID {
-		if (len(value) < 3) || (len(value) > 63) {
-			return fmt.Errorf("%q must contain from 3 to 63 characters", value)
-		}
-		if !regexp.MustCompile(`^[0-9a-z-.]+$`).MatchString(value) {
-			return fmt.Errorf("only lowercase alphanumeric characters and hyphens allowed in %q", value)
-		}
-		if regexp.MustCompile(`^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$`).MatchString(value) {
-			return fmt.Errorf("%q must not be formatted as an IP address", value)
-		}
-		if strings.HasPrefix(value, `.`) {
-			return fmt.Errorf("%q cannot start with a period", value)
-		}
-		if strings.HasSuffix(value, `.`) {
-			return fmt.Errorf("%q cannot end with a period", value)
-		}
-		if strings.Contains(value, `..`) {
-			return fmt.Errorf("%q can be only one period between labels", value)
-		}
-	} else {
-		if len(value) > 255 {
-			return fmt.Errorf("%q must contain less than 256 characters", value)
-		}
-		if !regexp.MustCompile(`^[0-9a-zA-Z-._]+$`).MatchString(value) {
-			return fmt.Errorf("only alphanumeric characters, hyphens, periods, and underscores allowed in %q", value)
-		}
+// ValidBucketName validates an S3 bucket name.
+// TODO: refactor as a SchemaValidateFunc.
+func ValidBucketName(value string) error {
+	if (len(value) < 3) || (len(value) > 63) {
+		return fmt.Errorf("%q must contain from 3 to 63 characters", value)
 	}
+	if !regexp.MustCompile(`^[0-9a-z-.]+$`).MatchString(value) {
+		return fmt.Errorf("only lowercase alphanumeric characters and hyphens allowed in %q", value)
+	}
+	if regexp.MustCompile(`^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$`).MatchString(value) {
+		return fmt.Errorf("%q must not be formatted as an IP address", value)
+	}
+	if strings.HasPrefix(value, `.`) {
+		return fmt.Errorf("%q cannot start with a period", value)
+	}
+	if strings.HasSuffix(value, `.`) {
+		return fmt.Errorf("%q cannot end with a period", value)
+	}
+	if strings.Contains(value, `..`) {
+		return fmt.Errorf("%q can be only one period between labels", value)
+	}
+
 	return nil
 }
 

--- a/internal/service/s3control/multi_region_access_point.go
+++ b/internal/service/s3control/multi_region_access_point.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/s3control"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -256,8 +255,12 @@ func resourceMultiRegionAccessPointDelete(d *schema.ResourceData, meta interface
 
 func ConnForMRAP(client *conns.AWSClient) (*s3control.S3Control, error) {
 	originalConn := client.S3ControlConn
+
+	// FIXME: if resources using this method are supported one day,
+	//  it will be easier to replace the aws region here.
+
 	// All Multi-Region Access Point actions are routed to the US West (Oregon) Region.
-	region := endpoints.UsWest2RegionID
+	region := "us-west-2" // lintignore:AWSAT003
 
 	if originalConn.Config.Region != nil && aws.StringValue(originalConn.Config.Region) == region {
 		return originalConn, nil

--- a/internal/service/sagemaker/prebuilt_ecr_image_data_source.go
+++ b/internal/service/sagemaker/prebuilt_ecr_image_data_source.go
@@ -3,7 +3,6 @@ package sagemaker
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -80,212 +79,33 @@ const (
 	sageMakerRepositoryHuggingFacePyTorchInference = "huggingface-pytorch-inference"
 )
 
-// https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-algo-docker-registry-paths.html
-var sageMakerPrebuiltECRImageIDByRegion_Blazing = map[string]string{
-	endpoints.AfSouth1RegionID:     "455444449433",
-	endpoints.ApEast1RegionID:      "286214385809",
-	endpoints.ApNortheast1RegionID: "501404015308",
-	endpoints.ApNortheast2RegionID: "306986355934",
-	endpoints.ApNortheast3RegionID: "867004704886",
-	endpoints.ApSouth1RegionID:     "991648021394",
-	endpoints.ApSoutheast1RegionID: "475088953585",
-	endpoints.ApSoutheast2RegionID: "544295431143",
-	endpoints.CaCentral1RegionID:   "469771592824",
-	endpoints.CnNorth1RegionID:     "390948362332",
-	endpoints.CnNorthwest1RegionID: "387376663083",
-	endpoints.EuCentral1RegionID:   "813361260812",
-	endpoints.EuNorth1RegionID:     "669576153137",
-	endpoints.EuSouth1RegionID:     "257386234256",
-	endpoints.EuWest1RegionID:      "685385470294",
-	endpoints.EuWest2RegionID:      "644912444149",
-	endpoints.EuWest3RegionID:      "749696950732",
-	endpoints.MeSouth1RegionID:     "249704162688",
-	endpoints.SaEast1RegionID:      "855470959533",
-	endpoints.UsEast1RegionID:      "811284229777",
-	endpoints.UsEast2RegionID:      "825641698319",
-	endpoints.UsGovWest1RegionID:   "226302683700",
-	endpoints.UsWest1RegionID:      "632365934929",
-	endpoints.UsWest2RegionID:      "433757028032",
-}
+// FIXME: get rid of all the maps below and probably of this resource.
 
 // https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-algo-docker-registry-paths.html
-var sageMakerPrebuiltECRImageIDByRegion_DeepAR = map[string]string{
-	endpoints.AfSouth1RegionID:     "455444449433",
-	endpoints.ApEast1RegionID:      "286214385809",
-	endpoints.ApNortheast1RegionID: "633353088612",
-	endpoints.ApNortheast2RegionID: "204372634319",
-	endpoints.ApSouth1RegionID:     "991648021394",
-	endpoints.ApSoutheast1RegionID: "475088953585",
-	endpoints.ApSoutheast2RegionID: "514117268639",
-	endpoints.CaCentral1RegionID:   "469771592824",
-	endpoints.CnNorth1RegionID:     "390948362332",
-	endpoints.CnNorthwest1RegionID: "387376663083",
-	endpoints.EuCentral1RegionID:   "495149712605",
-	endpoints.EuNorth1RegionID:     "669576153137",
-	endpoints.EuSouth1RegionID:     "257386234256",
-	endpoints.EuWest1RegionID:      "224300973850",
-	endpoints.EuWest2RegionID:      "644912444149",
-	endpoints.EuWest3RegionID:      "749696950732",
-	endpoints.MeSouth1RegionID:     "249704162688",
-	endpoints.SaEast1RegionID:      "855470959533",
-	endpoints.UsEast1RegionID:      "522234722520",
-	endpoints.UsEast2RegionID:      "566113047672",
-	endpoints.UsGovWest1RegionID:   "226302683700",
-	endpoints.UsWest1RegionID:      "632365934929",
-	endpoints.UsWest2RegionID:      "156387875391",
-}
+var sageMakerPrebuiltECRImageIDByRegion_Blazing = map[string]string{}
 
 // https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-algo-docker-registry-paths.html
-var PrebuiltECRImageIDByRegion_FactorMachines = map[string]string{
-	endpoints.AfSouth1RegionID:     "455444449433",
-	endpoints.ApEast1RegionID:      "286214385809",
-	endpoints.ApNortheast1RegionID: "351501993468",
-	endpoints.ApNortheast2RegionID: "835164637446",
-	endpoints.ApNortheast3RegionID: "867004704886",
-	endpoints.ApSouth1RegionID:     "991648021394",
-	endpoints.ApSoutheast1RegionID: "475088953585",
-	endpoints.ApSoutheast2RegionID: "712309505854",
-	endpoints.CaCentral1RegionID:   "469771592824",
-	endpoints.CnNorth1RegionID:     "390948362332",
-	endpoints.CnNorthwest1RegionID: "387376663083",
-	endpoints.EuCentral1RegionID:   "664544806723",
-	endpoints.EuNorth1RegionID:     "669576153137",
-	endpoints.EuSouth1RegionID:     "257386234256",
-	endpoints.EuWest1RegionID:      "438346466558",
-	endpoints.EuWest2RegionID:      "644912444149",
-	endpoints.EuWest3RegionID:      "749696950732",
-	endpoints.MeSouth1RegionID:     "249704162688",
-	endpoints.SaEast1RegionID:      "855470959533",
-	endpoints.UsEast1RegionID:      "382416733822",
-	endpoints.UsEast2RegionID:      "404615174143",
-	endpoints.UsGovWest1RegionID:   "226302683700",
-	endpoints.UsWest1RegionID:      "632365934929",
-	endpoints.UsWest2RegionID:      "174872318107",
-}
+var sageMakerPrebuiltECRImageIDByRegion_DeepAR = map[string]string{}
 
 // https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-algo-docker-registry-paths.html
-var sageMakerPrebuiltECRImageIDByRegion_LDA = map[string]string{
-	endpoints.ApNortheast1RegionID: "258307448986",
-	endpoints.ApNortheast2RegionID: "293181348795",
-	endpoints.ApSouth1RegionID:     "991648021394",
-	endpoints.ApSoutheast1RegionID: "475088953585",
-	endpoints.ApSoutheast2RegionID: "297031611018",
-	endpoints.CaCentral1RegionID:   "469771592824",
-	endpoints.EuCentral1RegionID:   "353608530281",
-	endpoints.EuWest1RegionID:      "999678624901",
-	endpoints.EuWest2RegionID:      "644912444149",
-	endpoints.UsEast1RegionID:      "766337827248",
-	endpoints.UsEast2RegionID:      "999911452149",
-	endpoints.UsGovWest1RegionID:   "226302683700",
-	endpoints.UsWest1RegionID:      "632365934929",
-	endpoints.UsWest2RegionID:      "266724342769",
-}
+var PrebuiltECRImageIDByRegion_FactorMachines = map[string]string{}
 
 // https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-algo-docker-registry-paths.html
-var sageMakerPrebuiltECRImageIDByRegion_XGBoost = map[string]string{
-	endpoints.AfSouth1RegionID:     "510948584623",
-	endpoints.ApEast1RegionID:      "651117190479",
-	endpoints.ApNortheast1RegionID: "354813040037",
-	endpoints.ApNortheast2RegionID: "366743142698",
-	endpoints.ApNortheast3RegionID: "867004704886",
-	endpoints.ApSouth1RegionID:     "720646828776",
-	endpoints.ApSoutheast1RegionID: "121021644041",
-	endpoints.ApSoutheast2RegionID: "783357654285",
-	endpoints.CaCentral1RegionID:   "341280168497",
-	endpoints.CnNorth1RegionID:     "450853457545",
-	endpoints.CnNorthwest1RegionID: "451049120500",
-	endpoints.EuCentral1RegionID:   "492215442770",
-	endpoints.EuNorth1RegionID:     "662702820516",
-	endpoints.EuSouth1RegionID:     "978288397137",
-	endpoints.EuWest1RegionID:      "141502667606",
-	endpoints.EuWest2RegionID:      "764974769150",
-	endpoints.EuWest3RegionID:      "659782779980",
-	endpoints.MeSouth1RegionID:     "801668240914",
-	endpoints.SaEast1RegionID:      "737474898029",
-	endpoints.UsEast1RegionID:      "683313688378",
-	endpoints.UsEast2RegionID:      "257758044811",
-	endpoints.UsGovWest1RegionID:   "414596584902",
-	endpoints.UsWest1RegionID:      "746614075791",
-	endpoints.UsWest2RegionID:      "246618743249",
-}
+var sageMakerPrebuiltECRImageIDByRegion_LDA = map[string]string{}
+
+// https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-algo-docker-registry-paths.html
+var sageMakerPrebuiltECRImageIDByRegion_XGBoost = map[string]string{}
 
 // https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-algo-docker-registry-paths.html
 // https://docs.aws.amazon.com/sagemaker/latest/dg/pre-built-docker-containers-scikit-learn-spark.html
-var PrebuiltECRImageIDByRegion_SparkML = map[string]string{
-	endpoints.AfSouth1RegionID:     "510948584623",
-	endpoints.ApEast1RegionID:      "651117190479",
-	endpoints.ApNortheast1RegionID: "354813040037",
-	endpoints.ApNortheast2RegionID: "366743142698",
-	endpoints.ApSouth1RegionID:     "720646828776",
-	endpoints.ApSoutheast1RegionID: "121021644041",
-	endpoints.ApSoutheast2RegionID: "783357654285",
-	endpoints.CaCentral1RegionID:   "341280168497",
-	endpoints.CnNorth1RegionID:     "450853457545",
-	endpoints.CnNorthwest1RegionID: "451049120500",
-	endpoints.EuCentral1RegionID:   "492215442770",
-	endpoints.EuNorth1RegionID:     "662702820516",
-	endpoints.EuSouth1RegionID:     "978288397137",
-	endpoints.EuWest1RegionID:      "141502667606",
-	endpoints.EuWest2RegionID:      "764974769150",
-	endpoints.EuWest3RegionID:      "659782779980",
-	endpoints.MeSouth1RegionID:     "801668240914",
-	endpoints.SaEast1RegionID:      "737474898029",
-	endpoints.UsEast1RegionID:      "683313688378",
-	endpoints.UsEast2RegionID:      "257758044811",
-	endpoints.UsGovWest1RegionID:   "414596584902",
-	endpoints.UsWest1RegionID:      "746614075791",
-	endpoints.UsWest2RegionID:      "246618743249",
-}
+var PrebuiltECRImageIDByRegion_SparkML = map[string]string{}
 
 // https://github.com/aws/deep-learning-containers/blob/master/available_images.md
 // https://github.com/aws/sagemaker-tensorflow-serving-container
-var sageMakerPrebuiltECRImageIDByRegion_DeepLearning = map[string]string{
-	endpoints.ApEast1RegionID:      "871362719292",
-	endpoints.ApNortheast1RegionID: "763104351884",
-	endpoints.ApNortheast2RegionID: "763104351884",
-	endpoints.ApSouth1RegionID:     "763104351884",
-	endpoints.ApSoutheast1RegionID: "763104351884",
-	endpoints.ApSoutheast2RegionID: "763104351884",
-	endpoints.CaCentral1RegionID:   "763104351884",
-	endpoints.CnNorth1RegionID:     "727897471807",
-	endpoints.CnNorthwest1RegionID: "727897471807",
-	endpoints.EuCentral1RegionID:   "763104351884",
-	endpoints.EuNorth1RegionID:     "763104351884",
-	endpoints.EuWest1RegionID:      "763104351884",
-	endpoints.EuWest2RegionID:      "763104351884",
-	endpoints.EuWest3RegionID:      "763104351884",
-	endpoints.MeSouth1RegionID:     "217643126080",
-	endpoints.SaEast1RegionID:      "763104351884",
-	endpoints.UsEast1RegionID:      "763104351884",
-	endpoints.UsEast2RegionID:      "763104351884",
-	endpoints.UsIsoEast1RegionID:   "886529160074",
-	endpoints.UsWest1RegionID:      "763104351884",
-	endpoints.UsWest2RegionID:      "763104351884",
-}
+var sageMakerPrebuiltECRImageIDByRegion_DeepLearning = map[string]string{}
 
 // https://github.com/aws/sagemaker-tensorflow-serving-container
-var sageMakerPrebuiltECRImageIDByRegion_TensorFlowServing = map[string]string{
-	endpoints.ApEast1RegionID:      "057415533634",
-	endpoints.ApNortheast1RegionID: "520713654638",
-	endpoints.ApNortheast2RegionID: "520713654638",
-	endpoints.ApSouth1RegionID:     "520713654638",
-	endpoints.ApSoutheast1RegionID: "520713654638",
-	endpoints.ApSoutheast2RegionID: "520713654638",
-	endpoints.CaCentral1RegionID:   "520713654638",
-	endpoints.CnNorth1RegionID:     "520713654638",
-	endpoints.CnNorthwest1RegionID: "520713654638",
-	endpoints.EuCentral1RegionID:   "520713654638",
-	endpoints.EuNorth1RegionID:     "520713654638",
-	endpoints.EuWest1RegionID:      "520713654638",
-	endpoints.EuWest2RegionID:      "520713654638",
-	endpoints.EuWest3RegionID:      "520713654638",
-	endpoints.MeSouth1RegionID:     "724002660598",
-	endpoints.SaEast1RegionID:      "520713654638",
-	endpoints.UsEast1RegionID:      "520713654638",
-	endpoints.UsEast2RegionID:      "520713654638",
-	endpoints.UsWest1RegionID:      "520713654638",
-	endpoints.UsWest2RegionID:      "520713654638",
-}
+var sageMakerPrebuiltECRImageIDByRegion_TensorFlowServing = map[string]string{}
 
 func DataSourcePrebuiltECRImage() *schema.Resource {
 	return &schema.Resource{

--- a/internal/service/securityhub/finding_aggregator_test.go
+++ b/internal/service/securityhub/finding_aggregator_test.go
@@ -150,7 +150,7 @@ resource "aws_securityhub_finding_aggregator" "test_aggregator" {
 
   depends_on = [aws_securityhub_account.example]
 }
-`, endpoints.EuWest1RegionID, endpoints.EuWest2RegionID, endpoints.UsEast1RegionID)
+`, endpoints.RuMskRegionID, endpoints.RuSpbRegionID, endpoints.RuSpbRegionID)
 }
 
 func testAccFindingAggregatorAllRegionsExceptSpecifiedConfig() string {
@@ -163,5 +163,5 @@ resource "aws_securityhub_finding_aggregator" "test_aggregator" {
 
   depends_on = [aws_securityhub_account.example]
 }
-`, endpoints.EuWest1RegionID, endpoints.EuWest2RegionID)
+`, endpoints.RuMskRegionID, endpoints.RuSpbRegionID)
 }

--- a/internal/service/serverlessrepo/cloudformation_stack_test.go
+++ b/internal/service/serverlessrepo/cloudformation_stack_test.go
@@ -315,7 +315,7 @@ func testAccCloudFormationStackNameNoPrefixImportStateIdFunc(resourceName string
 }
 
 func testAccCloudFormationApplicationID() string {
-	arnRegion := endpoints.UsEast1RegionID
+	arnRegion := endpoints.RuMskRegionID
 	arnAccountID := "297356227824"
 
 	return arn.ARN{

--- a/internal/service/serverlessrepo/cloudformation_stack_test.go
+++ b/internal/service/serverlessrepo/cloudformation_stack_test.go
@@ -317,10 +317,6 @@ func testAccCloudFormationStackNameNoPrefixImportStateIdFunc(resourceName string
 func testAccCloudFormationApplicationID() string {
 	arnRegion := endpoints.UsEast1RegionID
 	arnAccountID := "297356227824"
-	if acctest.Partition() == endpoints.AwsUsGovPartitionID {
-		arnRegion = endpoints.UsGovWest1RegionID
-		arnAccountID = "023102451235"
-	}
 
 	return arn.ARN{
 		Partition: acctest.Partition(),

--- a/internal/service/sns/topic_subscription_test.go
+++ b/internal/service/sns/topic_subscription_test.go
@@ -325,7 +325,7 @@ func TestAccSNSTopicSubscription_autoConfirmingEndpoint(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, sns.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckTopicSubscriptionDestroy,
@@ -355,7 +355,7 @@ func TestAccSNSTopicSubscription_autoConfirmingSecuredEndpoint(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, sns.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckTopicSubscriptionDestroy,

--- a/internal/service/transfer/server_data_source_test.go
+++ b/internal/service/transfer/server_data_source_test.go
@@ -68,7 +68,7 @@ func TestAccTransferServerDataSource_apigateway(t *testing.T) {
 	datasourceName := "data.aws_transfer_server.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, transfer.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/service/transfer/server_test.go
+++ b/internal/service/transfer/server_test.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/acmpca"
 	"github.com/aws/aws-sdk-go/service/transfer"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -887,7 +886,6 @@ func testAccServer_vpcEndpointID(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			testAccPreCheck(t)
-			acctest.PreCheckPartitionNot(t, endpoints.AwsUsGovPartitionID)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, transfer.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,

--- a/internal/service/transfer/server_test.go
+++ b/internal/service/transfer/server_test.go
@@ -664,7 +664,7 @@ func testAccServer_protocols(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, transfer.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckServerDestroy,
@@ -724,7 +724,7 @@ func testAccServer_apiGateway(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, transfer.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckServerDestroy,
@@ -753,7 +753,7 @@ func testAccServer_apiGateway_forceDestroy(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, transfer.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckServerDestroy,
@@ -920,7 +920,7 @@ func testAccServer_lambdaFunction(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t); testAccPreCheck(t) },
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, transfer.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckServerDestroy,

--- a/internal/service/waf/acc_test.go
+++ b/internal/service/waf/acc_test.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -71,19 +70,9 @@ func testAccLoggingConfigurationRegionProviderConfig() string {
 	return acctest.ConfigRegionalProvider(testAccGetLoggingConfigurationRegion())
 }
 
+// FIXME: testAccWafLoggingConfigurationRegion is always "". Fix it, if WAF Logging Configuration is supported.
+
 // testAccGetLoggingConfigurationRegion returns the WAF Logging Configurations region for testing
 func testAccGetLoggingConfigurationRegion() string {
-	if testAccWafLoggingConfigurationRegion != "" {
-		return testAccWafLoggingConfigurationRegion
-	}
-
-	// AWS Commercial: https://docs.aws.amazon.com/waf/latest/developerguide/classic-logging.html
-	// AWS GovCloud (US) - not available yet: https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-waf.html
-	// AWS China - not available yet
-	switch acctest.Partition() {
-	case endpoints.AwsPartitionID:
-		testAccWafLoggingConfigurationRegion = endpoints.UsEast1RegionID
-	}
-
 	return testAccWafLoggingConfigurationRegion
 }

--- a/internal/service/wafregional/web_acl_association_test.go
+++ b/internal/service/wafregional/web_acl_association_test.go
@@ -91,7 +91,6 @@ func TestAccWAFRegionalWebACLAssociation_ResourceARN_apiGatewayStage(t *testing.
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(wafregional.EndpointsID, t)
-			acctest.PreCheckAPIGatewayTypeEDGE(t)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, wafregional.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,

--- a/internal/service/wafv2/web_acl_association_test.go
+++ b/internal/service/wafv2/web_acl_association_test.go
@@ -24,7 +24,6 @@ func TestAccWAFV2WebACLAssociation_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
-			acctest.PreCheckAPIGatewayTypeEDGE(t)
 			testAccPreCheckScopeRegional(t)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, wafv2.EndpointsID),
@@ -56,7 +55,6 @@ func TestAccWAFV2WebACLAssociation_disappears(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
-			acctest.PreCheckAPIGatewayTypeEDGE(t)
 			testAccPreCheckScopeRegional(t)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, wafv2.EndpointsID),

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -9,6 +9,7 @@ description: |-
 [aws-tutorials]: https://learn.hashicorp.com/collections/terraform/aws?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS
 [c2-tutorials]: https://github.com/C2Devel/terraform-examples
 [hashicorp-tutorials]: https://learn.hashicorp.com/tutorials/terraform/infrastructure-as-code?in=terraform/aws-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS
+[k2-supported-regions]: https://docs.k2.cloud/en/security/isms.html#id2
 [terraform]: https://docs.k2.cloud/en/api/tools/terraform.html
 
 # Rockit Cloud Provider
@@ -39,7 +40,7 @@ terraform {
   required_providers {
     aws = {
       source  = "c2devel/rockitcloud"
-      version = "24.1.0"
+      version = "~> 25.2"
     }
   }
 }
@@ -47,6 +48,9 @@ terraform {
 # Configure the rockitcloud provider.
 # The section is named `aws` for backward compatibility.
 provider "aws" {
+  # For K2 Cloud, specify one of the supported regions.
+  # For other cloud platforms, enter a non-empty string,
+  # for example, "region-1", and API endpoints.
   region = "ru-msk"
 }
 
@@ -87,6 +91,11 @@ provider "aws" {
 
 The Rockit Cloud Provider manages resources via API calls. To connect the provider to the cloud platform,
 you must specify the platform API endpoints in the `provider.endpoints` block or define the corresponding environment variables.
+
+-> **Note**
+When connecting to K2 Cloud, you can specify one of [the supported regions][k2-supported-regions] in the configuration.
+In this case, the `provider.endpoints` block can be omitted,
+because the provider will generate all API endpoints based on the region value.
 
 Usage:
 


### PR DESCRIPTION
NOTES:

* Use K2 Cloud partition and regions

FEATURES:

* **New Data Source:** `aws_arn` (internal usage)
* **New Data Source:** `aws_partition` (internal usage)

ENHANCEMENTS:

* resource/aws_s3_bucket: 
  * remove location constraint population when creating bucket
  * update bucket name validation to comply with K2 Cloud restrictions across all regions
