### PR TITLE
Delete name_sufix from az data-source

### DIFF
--- a/internal/service/ec2/ec2_availability_zone_data_source.go
+++ b/internal/service/ec2/ec2_availability_zone_data_source.go
@@ -1,8 +1,6 @@
 package ec2
 
 import (
-	"strings"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -27,10 +25,6 @@ func DataSourceAvailabilityZone() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
-			},
-			"name_suffix": {
-				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"network_border_group": {
@@ -109,18 +103,9 @@ func dataSourceAvailabilityZoneRead(d *schema.ResourceData, meta interface{}) er
 		return tfresource.SingularDataSourceFindError("EC2 Availability Zone", err)
 	}
 
-	// As a convenience when working with AZs generically, we expose
-	// the AZ suffix alone, without the region name.
-	// This can be used e.g. to create lookup tables by AZ letter that
-	// work regardless of region.
-	nameSuffix := aws.StringValue(az.ZoneName)[len(aws.StringValue(az.RegionName)):]
-	// For Local and Wavelength zones, remove any leading "-".
-	nameSuffix = strings.TrimLeft(nameSuffix, "-")
-
 	d.SetId(aws.StringValue(az.ZoneName))
 	d.Set("group_name", az.GroupName)
 	d.Set("name", az.ZoneName)
-	d.Set("name_suffix", nameSuffix)
 	d.Set("network_border_group", az.NetworkBorderGroup)
 	d.Set("opt_in_status", az.OptInStatus)
 	d.Set("parent_zone_id", az.ParentZoneId)

--- a/internal/service/ec2/ec2_availability_zone_data_source_test.go
+++ b/internal/service/ec2/ec2_availability_zone_data_source_test.go
@@ -2,7 +2,6 @@ package ec2_test
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -26,7 +25,6 @@ func TestAccEC2AvailabilityZoneDataSource_allAvailabilityZones(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "group_name", acctest.Region()),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", availabilityZonesDataSourceName, "names.0"),
-					resource.TestMatchResourceAttr(dataSourceName, "name_suffix", regexp.MustCompile(`^[a-z]$`)),
 					resource.TestCheckResourceAttr(dataSourceName, "network_border_group", acctest.Region()),
 					resource.TestCheckResourceAttr(dataSourceName, "opt_in_status", ec2.AvailabilityZoneOptInStatusOptInNotRequired),
 					resource.TestCheckResourceAttr(dataSourceName, "parent_zone_id", ""),
@@ -54,7 +52,6 @@ func TestAccEC2AvailabilityZoneDataSource_filter(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "group_name", acctest.Region()),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", availabilityZonesDataSourceName, "names.0"),
-					resource.TestMatchResourceAttr(dataSourceName, "name_suffix", regexp.MustCompile(`^[a-z]$`)),
 					resource.TestCheckResourceAttr(dataSourceName, "network_border_group", acctest.Region()),
 					resource.TestCheckResourceAttr(dataSourceName, "opt_in_status", ec2.AvailabilityZoneOptInStatusOptInNotRequired),
 					resource.TestCheckResourceAttr(dataSourceName, "parent_zone_id", ""),
@@ -82,7 +79,6 @@ func TestAccEC2AvailabilityZoneDataSource_localZone(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "group_name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", availabilityZonesDataSourceName, "names.0"),
-					resource.TestMatchResourceAttr(dataSourceName, "name_suffix", regexp.MustCompile(`^[a-z0-9][a-z0-9-]+$`)),
 					resource.TestCheckResourceAttrSet(dataSourceName, "network_border_group"),
 					resource.TestCheckResourceAttr(dataSourceName, "opt_in_status", ec2.AvailabilityZoneOptInStatusOptedIn),
 					resource.TestCheckResourceAttrSet(dataSourceName, "parent_zone_id"),
@@ -110,7 +106,6 @@ func TestAccEC2AvailabilityZoneDataSource_name(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "group_name", acctest.Region()),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", availabilityZonesDataSourceName, "names.0"),
-					resource.TestMatchResourceAttr(dataSourceName, "name_suffix", regexp.MustCompile(`^[a-z]$`)),
 					resource.TestCheckResourceAttr(dataSourceName, "network_border_group", acctest.Region()),
 					resource.TestCheckResourceAttr(dataSourceName, "opt_in_status", ec2.AvailabilityZoneOptInStatusOptInNotRequired),
 					resource.TestCheckResourceAttr(dataSourceName, "parent_zone_id", ""),
@@ -138,7 +133,6 @@ func TestAccEC2AvailabilityZoneDataSource_wavelengthZone(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "group_name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", availabilityZonesDataSourceName, "names.0"),
-					resource.TestMatchResourceAttr(dataSourceName, "name_suffix", regexp.MustCompile(`^[a-z0-9][a-z0-9-]+$`)),
 					resource.TestCheckResourceAttrSet(dataSourceName, "network_border_group"),
 					resource.TestCheckResourceAttr(dataSourceName, "opt_in_status", ec2.AvailabilityZoneOptInStatusOptedIn),
 					resource.TestCheckResourceAttrSet(dataSourceName, "parent_zone_id"),
@@ -166,7 +160,6 @@ func TestAccEC2AvailabilityZoneDataSource_zoneID(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "group_name", acctest.Region()),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", availabilityZonesDataSourceName, "names.0"),
-					resource.TestMatchResourceAttr(dataSourceName, "name_suffix", regexp.MustCompile(`^[a-z]$`)),
 					resource.TestCheckResourceAttr(dataSourceName, "network_border_group", acctest.Region()),
 					resource.TestCheckResourceAttr(dataSourceName, "opt_in_status", ec2.AvailabilityZoneOptInStatusOptInNotRequired),
 					resource.TestCheckResourceAttr(dataSourceName, "parent_zone_id", ""),

--- a/website/docs/d/availability_zone.md
+++ b/website/docs/d/availability_zone.md
@@ -51,4 +51,4 @@ In addition to all arguments above, the following attributes are exported:
 
 The following attributes are not currently supported:
 
-`all_availability_zones`, `group_name`, `name_suffix`, `network_border_group`, `opt_in_status`, `parent_zone_id`, `parent_zone_name`, `zone_id`, `zone_type`.
+`all_availability_zones`, `group_name`, `network_border_group`, `opt_in_status`, `parent_zone_id`, `parent_zone_name`, `zone_id`, `zone_type`.


### PR DESCRIPTION
BUG FIXES:
- data-source/aws_availability_zone: delete unsupported attribute `name_sufix`