### PR TITLE
Drop aws.noregion from doc examples

### DIFF
--- a/website/docs/r/paas_service.md
+++ b/website/docs/r/paas_service.md
@@ -279,10 +279,6 @@ resource "aws_subnet" "subnet_comp1p" {
 
 resource "aws_s3_bucket" "example" {
   bucket = "tf-paas-backup"
-
-  # Use the predefined provider configuration to connect to object storage
-  # https://docs.k2.cloud/en/api/tools/terraform.html#providers-tf
-  provider = aws.noregion
 }
 
 resource "aws_paas_service" "pgsql" {

--- a/website/docs/r/s3_bucket.md
+++ b/website/docs/r/s3_bucket.md
@@ -55,10 +55,6 @@ Configuring with both will cause inconsistencies and may overwrite configuration
 resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
 
-  # Use the predefined provider configuration to connect to object storage
-  # https://docs.k2.cloud/en/api/tools/terraform.html#providers-tf
-  provider = aws.noregion
-
   tags = {
     Name        = "tf-example"
     Environment = "Dev"
@@ -80,10 +76,6 @@ Use the resource [`aws_s3_bucket_website_configuration`](s3_bucket_website_confi
 resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
   acl    = "public-read"
-
-  # Use the predefined provider configuration to connect to object storage
-  # https://docs.k2.cloud/en/api/tools/terraform.html#providers-tf
-  provider = aws.noregion
 
   website {
     index_document = "index.html"
@@ -113,10 +105,6 @@ resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
   acl    = "public-read"
 
-  # Use the predefined provider configuration to connect to object storage
-  # https://docs.k2.cloud/en/api/tools/terraform.html#providers-tf
-  provider = aws.noregion
-
   cors_rule {
     allowed_headers = ["*"]
     allowed_methods = ["PUT", "POST"]
@@ -137,10 +125,6 @@ resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
   acl    = "private"
 
-  # Use the predefined provider configuration to connect to object storage
-  # https://docs.k2.cloud/en/api/tools/terraform.html#providers-tf
-  provider = aws.noregion
-
   versioning {
     enabled = true
   }
@@ -156,10 +140,6 @@ Use the resource [`aws_s3_bucket_lifecycle_configuration`](s3_bucket_lifecycle_c
 resource "aws_s3_bucket" "bucket" {
   bucket = "tf-example"
   acl    = "private"
-
-  # Use the predefined provider configuration to connect to object storage
-  # https://docs.k2.cloud/en/api/tools/terraform.html#providers-tf
-  provider = aws.noregion
 
   lifecycle_rule {
     id      = "log"
@@ -192,10 +172,6 @@ resource "aws_s3_bucket" "versioning_bucket" {
   bucket = "tf-example"
   acl    = "private"
 
-  # Use the predefined provider configuration to connect to object storage
-  # https://docs.k2.cloud/en/api/tools/terraform.html#providers-tf
-  provider = aws.noregion
-
   versioning {
     enabled = true
   }
@@ -221,10 +197,6 @@ data "aws_canonical_user_id" "current_user" {}
 
 resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
-
-  # Use the predefined provider configuration to connect to object storage
-  # https://docs.k2.cloud/en/api/tools/terraform.html#providers-tf
-  provider = aws.noregion
 
   grant {
     id          = data.aws_canonical_user_id.current_user.id

--- a/website/docs/r/s3_bucket_acl.md
+++ b/website/docs/r/s3_bucket_acl.md
@@ -23,10 +23,6 @@ For more information about access rights for buckets, see [user documentation][a
 ```terraform
 resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
-
-  # Use the predefined provider configuration to connect to object storage
-  # https://docs.k2.cloud/en/api/tools/terraform.html#providers-tf
-  provider = aws.noregion
 }
 
 resource "aws_s3_bucket_acl" "example_bucket_acl" {
@@ -42,10 +38,6 @@ data "aws_canonical_user_id" "current" {}
 
 resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
-
-  # Use the predefined provider configuration to connect to object storage
-  # https://docs.k2.cloud/en/api/tools/terraform.html#providers-tf
-  provider = aws.noregion
 }
 
 resource "aws_s3_bucket_acl" "example" {

--- a/website/docs/r/s3_bucket_cors_configuration.md
+++ b/website/docs/r/s3_bucket_cors_configuration.md
@@ -19,10 +19,6 @@ Manages an S3 bucket CORS configuration. For more information about CORS, go to 
 ```terraform
 resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
-
-  # Use the predefined provider configuration to connect to object storage
-  # https://docs.k2.cloud/en/api/tools/terraform.html#providers-tf
-  provider = aws.noregion
 }
 
 resource "aws_s3_bucket_cors_configuration" "example" {

--- a/website/docs/r/s3_bucket_lifecycle_configuration.md
+++ b/website/docs/r/s3_bucket_lifecycle_configuration.md
@@ -32,10 +32,6 @@ The lifecycle rule applies to a subset of objects based on the key name prefix (
 # This bucket is used in all examples below
 resource "aws_s3_bucket" "bucket" {
   bucket = "tf-example"
-
-  # Use the predefined provider configuration to connect to object storage
-  # https://docs.k2.cloud/en/api/tools/terraform.html#providers-tf
-  provider = aws.noregion
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "example" {
@@ -197,10 +193,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "example" {
 ```terraform
 resource "aws_s3_bucket" "versioning_bucket" {
   bucket = "tf-example"
-
-  # Use the predefined provider configuration to connect to object storage
-  # https://docs.k2.cloud/en/api/tools/terraform.html#providers-tf
-  provider = aws.noregion
 }
 
 resource "aws_s3_bucket_acl" "versioning_bucket_acl" {

--- a/website/docs/r/s3_bucket_policy.md
+++ b/website/docs/r/s3_bucket_policy.md
@@ -19,10 +19,6 @@ Attaches a policy to an S3 bucket.
 ```terraform
 resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
-
-  # Use the predefined provider configuration to connect to object storage
-  # https://docs.k2.cloud/en/api/tools/terraform.html#providers-tf
-  provider = aws.noregion
 }
 
 resource "aws_s3_bucket_policy" "example" {

--- a/website/docs/r/s3_bucket_server_side_encryption_configuration.md
+++ b/website/docs/r/s3_bucket_server_side_encryption_configuration.md
@@ -23,10 +23,6 @@ resource "aws_kms_key" "mykey" {
 
 resource "aws_s3_bucket" "mybucket" {
   bucket = "mybucket"
-
-  # Use the predefined provider configuration to connect to object storage
-  # https://docs.k2.cloud/en/api/tools/terraform.html#providers-tf
-  provider = aws.noregion
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "example" {

--- a/website/docs/r/s3_bucket_versioning.md
+++ b/website/docs/r/s3_bucket_versioning.md
@@ -23,10 +23,6 @@ For more information about S3 versioning, see [user documentation][s3-versioning
 ```terraform
 resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
-
-  # Use the predefined provider configuration to connect to object storage
-  # https://docs.k2.cloud/en/api/tools/terraform.html#providers-tf
-  provider = aws.noregion
 }
 
 resource "aws_s3_bucket_acl" "example" {
@@ -47,10 +43,6 @@ resource "aws_s3_bucket_versioning" "versioning_example" {
 ```terraform
 resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
-
-  # Use the predefined provider configuration to connect to object storage
-  # https://docs.k2.cloud/en/api/tools/terraform.html#providers-tf
-  provider = aws.noregion
 }
 
 resource "aws_s3_bucket_acl" "example" {
@@ -77,10 +69,6 @@ This example shows the `aws_s3_object.example` depending implicitly on the versi
 ```terraform
 resource "aws_s3_bucket" "example" {
   bucket = "tf-example"
-
-  # Use the predefined provider configuration to connect to object storage
-  # https://docs.k2.cloud/en/api/tools/terraform.html#providers-tf
-  provider = aws.noregion
 }
 
 resource "aws_s3_bucket_versioning" "example" {


### PR DESCRIPTION
DOCUMENTATION FIXES:
 
* Remove `aws.noregion` provider usage from documentation examples