### PR TITLE
Bump aws-sdk-go to v1.44.10-ROCKIT17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/hashicorp/terraform-provider-aws
 
 go 1.21
 
-replace github.com/aws/aws-sdk-go => github.com/C2Devel/aws-sdk-go v1.44.10-ROCKIT16
+replace github.com/aws/aws-sdk-go => github.com/C2Devel/aws-sdk-go v1.44.10-ROCKIT17
 
 require (
 	github.com/ProtonMail/go-crypto v1.1.0-alpha.2

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/C2Devel/aws-sdk-go v1.44.10-ROCKIT16 h1:6dbPhhP52Ws1brNM9GvQ7WBNdhUgHv1TWQeP4ffVuG0=
-github.com/C2Devel/aws-sdk-go v1.44.10-ROCKIT16/go.mod h1:JCfES7rKS8ADm4DcmGHd2i0vL86B2b6rpVPkniCtJX8=
+github.com/C2Devel/aws-sdk-go v1.44.10-ROCKIT17 h1:VoXoZ/f+cE11HirEN9/zZHal8r/tBYG2Sb57vghq7js=
+github.com/C2Devel/aws-sdk-go v1.44.10-ROCKIT17/go.mod h1:JCfES7rKS8ADm4DcmGHd2i0vL86B2b6rpVPkniCtJX8=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97LyUpzH9P6Hrlg=


### PR DESCRIPTION
Bump aws-sdk-go to v1.44.10-ROCKIT17
- aws-sdk-go module is updated to v1.44.10-ROCKIT17