### PR TITLE
Получение kubeconfig через terraform

### DIFF
--- a/docs/data-sources/eks_cluster_kubeconfig.md
+++ b/docs/data-sources/eks_cluster_kubeconfig.md
@@ -1,0 +1,32 @@
+---
+subcategory: "EKS (Elastic Kubernetes)"
+layout: "aws"
+page_title: "aws_eks_cluster_kubeconfig"
+description: |-
+  Provides the kubeconfig for an EKS cluster.
+---
+
+# Data Source: aws_eks_cluster_kubeconfig
+
+Returns the kubeconfig string for an existing EKS cluster. The kubeconfig can
+be used to configure `kubectl` or other Kubernetes tooling.
+
+~> **NOTE:** The `kubeconfig` attribute is marked as sensitive because it
+contains credentials for the cluster.
+
+## Example Usage
+
+```terraform
+data "aws_eks_cluster_kubeconfig" "example" {
+  name = "example"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the cluster.
+
+## Attribute Reference
+
+* `id` - The name of the cluster.
+* `kubeconfig` - The kubeconfig for the cluster. This attribute is sensitive.

--- a/examples/eks/README.md
+++ b/examples/eks/README.md
@@ -13,6 +13,12 @@ $ terraform init
 $ terraform apply
 ```
 
+Get kubeconfig for the created cluster:
+
+```
+$ terraform output -raw kubeconfig > ~/.kube/config
+```
+
 Destroying the example:
 
 ```

--- a/examples/eks/eks-cluster.tf
+++ b/examples/eks/eks-cluster.tf
@@ -46,3 +46,12 @@ resource "aws_eks_cluster" "example" {
     Name = "terraform-eks-example"
   }
 }
+
+data "aws_eks_cluster_kubeconfig" "example_config" {
+  name = "terraform-eks-example"
+}
+
+output "kubeconfig" {
+  value     = data.aws_eks_cluster_kubeconfig.example_config.kubeconfig
+  sensitive = true
+}

--- a/infrastructure/repository/labels-service.tf
+++ b/infrastructure/repository/labels-service.tf
@@ -98,6 +98,7 @@ variable "service_labels" {
     "ecs",
     "efs",
     "eks",
+    "ekslegacy",
     "elasticache",
     "elasticbeanstalk",
     "elasticinference",

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -105,6 +105,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/efs"
 	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/aws/aws-sdk-go/service/ekslegacy"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/aws/aws-sdk-go/service/elasticbeanstalk"
 	"github.com/aws/aws-sdk-go/service/elasticinference"
@@ -417,6 +418,7 @@ type AWSClient struct {
 	ECSConn                          *ecs.ECS
 	EFSConn                          *efs.EFS
 	EKSConn                          *eks.EKS
+	EKSLegacyConn                    *ekslegacy.EKSLegacy
 	ELBConn                          *elb.ELB
 	ELBV2Conn                        *elbv2.ELBV2
 	EMRConn                          *emr.EMR

--- a/internal/conns/config_gen.go
+++ b/internal/conns/config_gen.go
@@ -103,6 +103,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/efs"
 	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/aws/aws-sdk-go/service/ekslegacy"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/aws/aws-sdk-go/service/elasticbeanstalk"
 	"github.com/aws/aws-sdk-go/service/elasticinference"
@@ -396,6 +397,7 @@ func (c *Config) clientConns(sess *session.Session) *AWSClient {
 		ECSConn:                          ecs.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ECS])})),
 		EFSConn:                          efs.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.EFS])})),
 		EKSConn:                          eks.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.EKS])})),
+		EKSLegacyConn:                    ekslegacy.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.EKSLegacy])})),
 		ELBConn:                          elb.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ELB])})),
 		ELBV2Conn:                        elbv2.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ELBV2])})),
 		EMRConn:                          emr.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.EMR])})),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -467,11 +467,13 @@ func Provider() *schema.Provider {
 
 			// "aws_eks_addon":         eks.DataSourceAddon(),
 			// "aws_eks_addon_version": eks.DataSourceAddonVersion(),
-			"aws_eks_cluster":      eks.DataSourceCluster(),
-			"aws_eks_clusters":     eks.DataSourceClusters(),
-			"aws_eks_cluster_auth": eks.DataSourceClusterAuth(),
-			"aws_eks_node_group":   eks.DataSourceNodeGroup(),
-			"aws_eks_node_groups":  eks.DataSourceNodeGroups(),
+			"aws_eks_cluster":            eks.DataSourceCluster(),
+			"aws_eks_clusters":           eks.DataSourceClusters(),
+			"aws_eks_cluster_auth":       eks.DataSourceClusterAuth(),
+			"aws_eks_cluster_kubeconfig": eks.DataSourceClusterKubeconfig(),
+
+			"aws_eks_node_group":  eks.DataSourceNodeGroup(),
+			"aws_eks_node_groups": eks.DataSourceNodeGroups(),
 
 			// "aws_elasticache_cluster":           elasticache.DataSourceCluster(),
 			// "aws_elasticache_replication_group": elasticache.DataSourceReplicationGroup(),

--- a/internal/service/eks/cluster_kubeconfig_data_source.go
+++ b/internal/service/eks/cluster_kubeconfig_data_source.go
@@ -1,0 +1,50 @@
+package eks
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ekslegacy"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func DataSourceClusterKubeconfig() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceClusterKubeconfigRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+
+			"kubeconfig": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func dataSourceClusterKubeconfigRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).EKSLegacyConn
+	name := d.Get("name").(string)
+
+	input := &ekslegacy.GetClusterKubeconfigInput{
+		Name: aws.String(name),
+	}
+
+	output, err := conn.GetClusterKubeconfig(input)
+	if err != nil {
+		return fmt.Errorf("error reading EKS Cluster kubeconfig (%s): %w", name, err)
+	}
+
+	d.SetId(name)
+	d.Set("kubeconfig", output.Kubeconfig)
+
+	return nil
+}

--- a/internal/service/eks/cluster_kubeconfig_data_source_test.go
+++ b/internal/service/eks/cluster_kubeconfig_data_source_test.go
@@ -1,0 +1,34 @@
+package eks_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccEKSClusterKubeconfigDataSource_basic(t *testing.T) {
+	dataSourceResourceName := "data.aws_eks_cluster_kubeconfig.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, eks.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterKubeconfigDataSourceConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceResourceName, "name", "foobar"),
+					resource.TestCheckResourceAttrSet(dataSourceResourceName, "kubeconfig"),
+				),
+			},
+		},
+	})
+}
+
+const testAccClusterKubeconfigDataSourceConfig_basic = `
+data "aws_eks_cluster_kubeconfig" "test" {
+  name = "foobar"
+}
+`

--- a/names/consts_gen.go
+++ b/names/consts_gen.go
@@ -97,6 +97,7 @@ const (
 	ECS                          = "ecs"
 	EFS                          = "efs"
 	EKS                          = "eks"
+	EKSLegacy                    = "ekslegacy"
 	ELB                          = "elb"
 	ELBV2                        = "elbv2"
 	EMR                          = "emr"

--- a/names/names_data.csv
+++ b/names/names_data.csv
@@ -125,6 +125,7 @@ ecr-public,ecrpublic,ecrpublic,ecrpublic,,ecrpublic,,,ECRPublic,ECRPublic,,1,,aw
 ecs,ecs,ecs,ecs,,ecs,,,ECS,ECS,,1,,aws_ecs_,,ecs_,ECS (Elastic Container),Amazon,,,,,
 efs,efs,efs,efs,,efs,,,EFS,EFS,,1,,aws_efs_,,efs_,EFS (Elastic File System),Amazon,,,,,
 eks,eks,eks,eks,,eks,,,EKS,EKS,,1,,aws_eks_,,eks_,EKS (Elastic Kubernetes),Amazon,,,,,
+eks-legacy,ekslegacy,ekslegacy,ekslegacy,,ekslegacy,,,EKSLegacy,EKSLegacy,,1,,aws_ekslegacy_,,ekslegacy_,EKS Legacy (Elastic Kubernetes),Amazon,,,,,
 elasticbeanstalk,elasticbeanstalk,elasticbeanstalk,elasticbeanstalk,,elasticbeanstalk,,,ElasticBeanstalk,ElasticBeanstalk,,1,aws_elastic_beanstalk_,aws_elasticbeanstalk_,,elastic_beanstalk_,Elastic Beanstalk,AWS,,,,,
 elastic-inference,elasticinference,elasticinference,elasticinference,,elasticinference,,,ElasticInference,ElasticInference,,1,,aws_elasticinference_,,elasticinference_,Elastic Inference,Amazon,,,,,
 elastictranscoder,elastictranscoder,elastictranscoder,elastictranscoder,,elastictranscoder,,,ElasticTranscoder,ElasticTranscoder,,1,,aws_elastictranscoder_,,elastictranscoder_,Elastic Transcoder,Amazon,,,,,

--- a/names/names_test.go
+++ b/names/names_test.go
@@ -96,6 +96,7 @@ func TestServicesForDirectories(t *testing.T) {
 		"dynamodbstreams",
 		"ebs",
 		"ec2instanceconnect",
+		"ekslegacy",
 		"elasticinference",
 		"emrcontainers",
 		"evidently",


### PR DESCRIPTION
Relasted with https://github.com/C2Devel/aws-sdk-go/pull/61


aws-sdk-go=pr-add-kubeconfig-route


Добавили возможность получать конфиг для подключения в Kubernetes через Terraform

\`\`\`release-note:enhancement
data-sources: Add `aws_eks_cluster_kubeconfig` data source
\`\`\`
