### PR TITLE
paas: added extension vector and fix pg_visibility

### DIFF
--- a/.changelog/166.txt
+++ b/.changelog/166.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/aws_paas_service: Add `vector` as a valid PostgreSQL extension
+```
+
+```release-note:bug
+resource/aws_paas_service: Fix validation of the `pg_visibility` PostgreSQL extension
+```
+
+```release-note:enhancement
+resource/aws_paas_service: Make `ssh_key_name` optional
+```

--- a/internal/service/paas/service.go
+++ b/internal/service/paas/service.go
@@ -375,7 +375,7 @@ func ResourceService() *schema.Resource {
 			},
 			"ssh_key_name": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 			"status": {

--- a/internal/service/paas/services/parameter_values.go
+++ b/internal/service/paas/services/parameter_values.go
@@ -57,7 +57,7 @@ func postgreSQLDatabaseExtensions() []string {
 		"moddatetime",
 		"pg_buffercache",
 		"pg_trgm",
-		"pg_visibility ",
+		"pg_visibility",
 		"pgcrypto",
 		"pgrowlocks",
 		"pgstattuple",
@@ -73,6 +73,7 @@ func postgreSQLDatabaseExtensions() []string {
 		"tsm_system_time",
 		"unaccent",
 		"uuid-ossp",
+		"vector",
 		"xml2",
 	}
 }


### PR DESCRIPTION
ENHANCEMENTS:

resource/aws_paas_service: add `vector` extension support for PostgreSQL and make `ssh_key_name` optional

BUG:
resource/aws_paas_service: fix `pg_visibility` PostgreSQL extension validation
