### PR TITLE
Enhancement EKS

### DIFF
--- a/.changelog/177.txt
+++ b/.changelog/177.txt
@@ -1,0 +1,15 @@
+```release-note:enhancement
+resource/aws_eks_cluster: Add K2Cloud Pod CIDR, remote access, Cluster Autoscaler, in-place security group updates, and in-place user-data updates
+```
+
+```release-note:enhancement
+resource/aws_eks_cluster: Propagate K2Cloud health and update failures from waiters and align delete timeouts
+```
+
+```release-note:enhancement
+resource/aws_eks_node_group: Reject unsupported version and custom launch-template inputs while preserving platform-managed launch-template state
+```
+
+```release-note:enhancement
+data-source/aws_eks_cluster_auth: Return an actionable error directing K2Cloud users to `aws_eks_cluster_kubeconfig`
+```

--- a/docs/data-sources/eks_cluster_auth.md
+++ b/docs/data-sources/eks_cluster_auth.md
@@ -8,21 +8,19 @@ description: |-
 
 # Data Source: aws_eks_cluster_auth
 
-Provides information about an authentication token to communicate with an EKS cluster.
+This AWS-compatible data source is not supported by K2 EKS. K2 clusters use a
+certificate-based kubeconfig instead of an IAM authentication token. Reading
+this data source returns an explicit error.
 
-## Example Usage
+Use `aws_eks_cluster_kubeconfig`:
 
 ```terraform
-data "aws_eks_cluster_auth" "example" {
+data "aws_eks_cluster_kubeconfig" "example" {
   name = "example"
 }
+
+output "kubeconfig" {
+  value     = data.aws_eks_cluster_kubeconfig.example.kubeconfig
+  sensitive = true
+}
 ```
-
-## Argument Reference
-
-* `name` - (Required) The name of the cluster.
-
-## Attribute Reference
-
-* `id` - The name of the cluster.
-* `token` - The token to use to authenticate with the cluster.

--- a/docs/resources/eks_cluster.md
+++ b/docs/resources/eks_cluster.md
@@ -88,6 +88,10 @@ resource "aws_eks_cluster" "example" {
   version = "1.30.2"
 
   legacy_cluster_params {
+    cluster_autoscaler_config {
+      cluster_autoscaler_required = true
+    }
+
     docker_registry_config {
       volume_type = "gp2"
       volume_size = 32
@@ -175,6 +179,8 @@ The following arguments are optional:
 * `kubernetes_network_config` - (Optional) Configuration block with kubernetes network configuration for the cluster. Detailed below. If removed, Terraform will only perform drift detection if a configuration value is provided.
 * `legacy_cluster_params` - (Optional) The parameters for fine-tuning the Kubernetes cluster.
   The structure of this block is [described below](#legacy_cluster_params).
+* `remote_access_config` - (Optional) K2 control-plane remote access configuration. The block accepts `ec2_ssh_key`.
+* `role_arn` - (Optional) K2 service-user ARN. Empty values are not sent to the API.
 * `tags` - (Optional) Map of tags to assign to the cluster. If a provider [`default_tags` configuration block][default-tags] is used, tags with matching keys will overwrite those defined at the provider level.
 
 ### kubernetes_network_config
@@ -183,6 +189,7 @@ The following arguments are supported in the `kubernetes_network_config` configu
 
 * `ip_family` - (Optional) The IP family used to assign Kubernetes pod and service addresses.
     * _Valid values:_ `ipv4`
+* `pod_ipv4_cidr` - (Optional) The CIDR block to assign Kubernetes pod IP addresses from.
 * `service_ipv4_cidr` - (Optional) The CIDR block to assign Kubernetes service IP addresses from. If you don't specify a block, Kubernetes assigns addresses from 10.96.0.0/12 CIDR block.
 The block must meet the following requirements:
     * Within one of the following private IP address blocks: 10.0.0.0/8, 172.16.0.0/12, or 192.168.0.0/16.
@@ -193,13 +200,14 @@ The block must meet the following requirements:
 
 The `legacy_cluster_params` block has the following structure:
 
+* `cluster_autoscaler_config` – (Optional) The configuration of the Cluster Autoscaler.
 * `docker_registry_config` – (Optional) The configuration of the Docker Registry.
   The structure of this block is [described below](#docker_registry_config).
 * `ebs_provider_config` – (Optional) The configuration of the EBS Provider.
   The structure of this block is [described below](#ebs_provider_config).
 * `ingress_config` – (Optional) The configuration of the Ingress controller.
   The structure of this block is [described below](#ingress_config).
-* `master_config` - (Optional) The configuration of the master node of the cluster.
+* `master_config` - (Required) The configuration of the master node of the cluster.
   The structure of this block is [described below](#master_config).
 * `nlb_provider_config` – (Optional) The configuration of the NLB Provider.
   The structure of this block is [described below](#nlb_provider_config).
@@ -208,6 +216,11 @@ The `legacy_cluster_params` block has the following structure:
 * `user_data_config` - (Optional) The configuration of the cluster user data.
   The structure of this block is [described below](#user_data_config).
 
+
+#### cluster_autoscaler_config
+
+* `cluster_autoscaler_required` - (Required) Whether to deploy the Cluster Autoscaler.
+* `cluster_autoscaler_user` - (Optional) K2 service user used by the Cluster Autoscaler.
 
 #### docker_registry_config
 
@@ -256,7 +269,7 @@ The `nlb_provider_config` block has the following structure:
 ### vpc_config
 
 * `subnet_ids` - (Required) List of subnet IDs.
-* `security_group_ids` - (Optional) List of security group IDs.
+* `security_group_ids` - (Optional) List of security group IDs. Changes are applied in place through the K2 cluster update API.
 
 #### placement_config
 
@@ -279,6 +292,11 @@ The `user_data_config` block has the following structure:
 * `user_data_content_type` - (Required) The type of `user_data`.
     * _Valid values:_ `cloud-config`,  `x-shellscript`
 
+Changes to `user_data_config` are applied in place through
+`UpdateClusterUserData`. The current K2 backend returned `InternalError` during
+live verification, so validate this operation in the target environment before
+depending on it in production.
+
 ## Attribute Reference
 
 ### Supported attributes
@@ -291,7 +309,8 @@ In addition to all arguments above, the following attributes are exported:
 * `created_at` - The Unix epoch time stamp in seconds for when the cluster was created.
 * `id` - The name of the cluster.
 * `platform_version` - The platform version for the cluster.
-* `status` - The status of the EKS cluster. One of `CLAIMED`, `CREATING`, `DELETED`, `DELETING`, `ERROR`, `MODIFYING`, `PENDING`, `PROVISIONING`, `READY`, `REPAIRING`.
+* `status` - The status of the EKS cluster. One of `CLAIMED`, `CREATING`, `DELETED`, `DELETING`, `ERROR`, `FAILED`, `MODIFYING`, `PENDING`, `PROVISIONING`, `READY`, `REPAIRING`, `UPDATING`.
+Cluster creation and deletion waiter failures include health issue details returned by K2.
 * `tags_all` - Map of tags assigned to the cluster, including those inherited from the provider [`default_tags` configuration block][default-tags].
 * `vpc_config` -  Nested list containing VPC configuration for the cluster.
     * `cluster_security_group_id` - The cluster security group that was created by the cloud for the cluster.
@@ -303,7 +322,7 @@ In addition to all arguments above, the following attributes are exported:
 
 The following attributes are not currently supported:
 
-`enabled_cluster_log_types`, `encryption_config`, `endpoint`, `identity`, `role_arn`, `vpc_config.endpoint_private_access`, `vpc_config.endpoint_public_access`, `vpc_config.public_access_cidrs`.
+`enabled_cluster_log_types`, `encryption_config`, `endpoint`, `identity`, `vpc_config.endpoint_private_access`, `vpc_config.endpoint_public_access`, `vpc_config.public_access_cidrs`.
 
 ## Timeouts
 
@@ -312,7 +331,7 @@ The `timeouts` block allows you to specify [timeouts] for certain actions:
 * `create` - (Default `30 minutes`) How long to wait for the EKS cluster to be created.
 * `update` - (Default `60 minutes`) How long to wait for the EKS cluster to be updated.
 Note that the `update` timeout is used separately for both `version` and `vpc_config` update timeouts.
-* `delete` - (Default `15 minutes`) How long to wait for the EKS cluster to be deleted.
+* `delete` - (Default `60 minutes`) How long to wait for the EKS cluster to be deleted.
 
 ## Import
 

--- a/docs/resources/eks_node_group.md
+++ b/docs/resources/eks_node_group.md
@@ -114,7 +114,7 @@ The following arguments are optional:
 
 * `desired_size` - (Required) Desired number of worker nodes.
 * `max_size` - (Required) Maximum number of worker nodes.
-* `min_size` - (Required) Minimum number of worker nodes.
+* `min_size` - (Required) Minimum number of worker nodes. Must be at least `1`.
 
 ### taint
 
@@ -140,7 +140,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `arn` - EKS node group ID.
 * `id` - EKS cluster name and EKS node group name separated by a colon (`:`).
-* `launch_template` - Configuration block with launch template settings.
+* `launch_template` - Computed configuration for the platform-managed launch template. Custom launch templates cannot be configured.
     * `id` - EC2 launch template ID.
     * `name` - Name of the EC2 launch template.
     * `version` - EC2 launch template version number.
@@ -157,7 +157,7 @@ In addition to all arguments above, the following attributes are exported:
 
 The following attributes are not currently supported:
 
-`ami_type`, `force_update_version`, `node_role_arn`, `release_version`, `remote_access.source_security_group_ids`, `resources.remote_access_security_group_id`.
+`ami_type`, `force_update_version`, `node_role_arn`, `release_version`, configurable `version`, `remote_access.source_security_group_ids`, `resources.remote_access_security_group_id`.
 
 ## Timeouts
 
@@ -167,7 +167,7 @@ The `timeouts` block allows you to specify [timeouts] for certain actions:
 * `update` - (Default `60 minutes`) How long to wait for the EKS node group to be updated.
 * `delete` - (Default `60 minutes`) How long to wait for the EKS node group to be deleted.
 
-~> **Note** The `update` timeout is used separately for both configuration and version update operations.
+~> **Note** K2 node groups inherit the cluster Kubernetes version; version-update arguments are not supported.
 
 ## Import
 

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -37,18 +36,12 @@ func ResourceCluster() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
-		CustomizeDiff: customdiff.Sequence(
-			verify.SetTagsDiff,
-			customdiff.ForceNewIfChange("encryption_config", func(_ context.Context, old, new, meta interface{}) bool {
-				// You cannot disable envelope encryption after enabling it. This action is irreversible.
-				return len(old.([]interface{})) == 1 && len(new.([]interface{})) == 0
-			}),
-		),
+		CustomizeDiff: verify.SetTagsDiff,
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
 			Update: schema.DefaultTimeout(60 * time.Minute),
-			Delete: schema.DefaultTimeout(15 * time.Minute),
+			Delete: schema.DefaultTimeout(clusterDeleteRetryTimeout),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -74,7 +67,7 @@ func ResourceCluster() *schema.Resource {
 			},
 			"enabled_cluster_log_types": {
 				Type:     schema.TypeSet,
-				Optional: true,
+				Computed: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: validation.StringInSlice(eks.LogType_Values(), true),
@@ -83,26 +76,24 @@ func ResourceCluster() *schema.Resource {
 			},
 			"encryption_config": {
 				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"provider": {
 							Type:     schema.TypeList,
-							MaxItems: 1,
-							Required: true,
+							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"key_arn": {
 										Type:     schema.TypeString,
-										Required: true,
+										Computed: true,
 									},
 								},
 							},
 						},
 						"resources": {
 							Type:     schema.TypeSet,
-							Required: true,
+							Computed: true,
 							Elem: &schema.Schema{
 								Type:         schema.TypeString,
 								ValidateFunc: validation.StringInSlice(Resources_Values(), false),
@@ -159,6 +150,13 @@ func ResourceCluster() *schema.Resource {
 								validation.StringMatch(regexp.MustCompile(`^(10|172\.(1[6-9]|2[0-9]|3[0-1])|192\.168)\..*`), "must be within 10.0.0.0/8, 172.16.0.0/12, or 192.168.0.0/16"),
 							),
 						},
+						"pod_ipv4_cidr": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.IsCIDR,
+						},
 					},
 				},
 			},
@@ -169,6 +167,25 @@ func ResourceCluster() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"cluster_autoscaler_config": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"cluster_autoscaler_required": {
+										Type:     schema.TypeBool,
+										Required: true,
+										ForceNew: true,
+									},
+									"cluster_autoscaler_user": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
+									},
+								},
+							},
+						},
 						"docker_registry_config": {
 							Type:     schema.TypeList,
 							Optional: true,
@@ -243,7 +260,7 @@ func ResourceCluster() *schema.Resource {
 						},
 						"master_config": {
 							Type:     schema.TypeList,
-							Optional: true,
+							Required: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -289,12 +306,10 @@ func ResourceCluster() *schema.Resource {
 									"user_data": {
 										Type:     schema.TypeString,
 										Required: true,
-										ForceNew: true,
 									},
 									"user_data_content_type": {
 										Type:     schema.TypeString,
 										Required: true,
-										ForceNew: true,
 										ValidateFunc: validation.StringInSlice(
 											[]string{"cloud-config", "x-shellscript"},
 											false,
@@ -341,6 +356,7 @@ func ResourceCluster() *schema.Resource {
 									"host_id": {
 										Type:     schema.TypeString,
 										Optional: true,
+										ForceNew: true,
 									},
 								},
 							},
@@ -353,6 +369,22 @@ func ResourceCluster() *schema.Resource {
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validClusterName,
+			},
+			"remote_access_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ec2_ssh_key": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+					},
+				},
 			},
 			"platform_version": {
 				Type:     schema.TypeString,
@@ -388,15 +420,14 @@ func ResourceCluster() *schema.Resource {
 						},
 						"endpoint_private_access": {
 							Type:     schema.TypeBool,
-							Optional: true,
+							Computed: true,
 						},
 						"endpoint_public_access": {
 							Type:     schema.TypeBool,
-							Optional: true,
+							Computed: true,
 						},
 						"public_access_cidrs": {
 							Type:     schema.TypeSet,
-							Optional: true,
 							Computed: true,
 							Elem: &schema.Schema{
 								Type:         schema.TypeString,
@@ -406,7 +437,6 @@ func ResourceCluster() *schema.Resource {
 						"security_group_ids": {
 							Type:     schema.TypeSet,
 							Optional: true,
-							ForceNew: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"subnet_ids": {
@@ -434,25 +464,12 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 	name := d.Get("name").(string)
 
 	input := &eks.CreateClusterInput{
-		EncryptionConfig:   testAccClusterConfig_expandEncryption(d.Get("encryption_config").([]interface{})),
 		Name:               aws.String(name),
 		ResourcesVpcConfig: testAccClusterConfig_expandVPCRequest(d.Get("vpc_config").([]interface{})),
-		RoleArn:            aws.String(d.Get("role_arn").(string)),
 	}
 
-	// endpoint_private_access and endpoint_public_access are removed from CreateCluster input
-	// if they aren't specified in the configuration.
-	//
-	// FIXME: Remove after these parameters are supported in C2 EKS API.
-	if _, exists := d.GetOkExists("vpc_config.0.endpoint_private_access"); !exists {
-		input.ResourcesVpcConfig.EndpointPrivateAccess = nil
-	}
-	if _, exists := d.GetOkExists("vpc_config.0.endpoint_public_access"); !exists {
-		input.ResourcesVpcConfig.EndpointPublicAccess = nil
-	}
-
-	if _, ok := d.GetOk("enabled_cluster_log_types"); ok {
-		input.Logging = expandLoggingTypes(d.Get("enabled_cluster_log_types").(*schema.Set))
+	if v, ok := d.GetOk("role_arn"); ok && v.(string) != "" {
+		input.RoleArn = aws.String(v.(string))
 	}
 
 	if _, ok := d.GetOk("kubernetes_network_config"); ok {
@@ -461,6 +478,10 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("legacy_cluster_params"); ok {
 		input.LegacyClusterParams = expandLegacyClusterParams(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("remote_access_config"); ok {
+		input.RemoteAccessConfig = expandClusterRemoteAccessConfig(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("version"); ok {
@@ -588,6 +609,10 @@ func resourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error setting legacy_cluster_params: %w", err)
 	}
 
+	if err := d.Set("remote_access_config", flattenClusterRemoteAccessConfig(cluster.RemoteAccessConfig)); err != nil {
+		return fmt.Errorf("error setting remote_access_config: %w", err)
+	}
+
 	d.Set("name", cluster.Name)
 	d.Set("platform_version", cluster.PlatformVersion)
 	d.Set("role_arn", cluster.RoleArn)
@@ -616,88 +641,17 @@ func resourceClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EKSConn
 	connEc2 := meta.(*conns.AWSClient).EC2Conn
 
-	// Do any version update first.
-	if d.HasChange("version") {
-		input := &eks.UpdateClusterVersionInput{
-			Name:    aws.String(d.Id()),
-			Version: aws.String(d.Get("version").(string)),
-		}
-
-		log.Printf("[DEBUG] Updating EKS Cluster (%s) version: %s", d.Id(), input)
-		output, err := conn.UpdateClusterVersion(input)
-
-		if err != nil {
-			return fmt.Errorf("error updating EKS Cluster (%s) version: %w", d.Id(), err)
-		}
-
-		updateID := aws.StringValue(output.Update.Id)
-
-		_, err = waitClusterUpdateSuccessful(conn, d.Id(), updateID, d.Timeout(schema.TimeoutUpdate))
-
-		if err != nil {
-			return fmt.Errorf("error waiting for EKS Cluster (%s) version update (%s): %w", d.Id(), updateID, err)
-		}
-	}
-
-	if d.HasChange("encryption_config") {
-		o, n := d.GetChange("encryption_config")
-
-		if len(o.([]interface{})) == 0 && len(n.([]interface{})) == 1 {
-			input := &eks.AssociateEncryptionConfigInput{
-				ClusterName:      aws.String(d.Id()),
-				EncryptionConfig: testAccClusterConfig_expandEncryption(d.Get("encryption_config").([]interface{})),
-			}
-
-			log.Printf("[DEBUG] Associating EKS Cluster (%s) encryption config: %s", d.Id(), input)
-			output, err := conn.AssociateEncryptionConfig(input)
-
-			if err != nil {
-				return fmt.Errorf("error associating EKS Cluster (%s) encryption config: %w", d.Id(), err)
-			}
-
-			updateID := aws.StringValue(output.Update.Id)
-
-			_, err = waitClusterUpdateSuccessful(conn, d.Id(), updateID, d.Timeout(schema.TimeoutUpdate))
-
-			if err != nil {
-				return fmt.Errorf("error waiting for EKS Cluster (%s) encryption config association (%s): %w", d.Id(), updateID, err)
-			}
-		}
-	}
-
-	if d.HasChange("enabled_cluster_log_types") {
-		input := &eks.UpdateClusterConfigInput{
-			Logging: expandLoggingTypes(d.Get("enabled_cluster_log_types").(*schema.Set)),
-			Name:    aws.String(d.Id()),
-		}
-
-		log.Printf("[DEBUG] Updating EKS Cluster (%s) logging: %s", d.Id(), input)
-		output, err := conn.UpdateClusterConfig(input)
-
-		if err != nil {
-			return fmt.Errorf("error updating EKS Cluster (%s) logging: %w", d.Id(), err)
-		}
-
-		updateID := aws.StringValue(output.Update.Id)
-
-		_, err = waitClusterUpdateSuccessful(conn, d.Id(), updateID, d.Timeout(schema.TimeoutUpdate))
-
-		if err != nil {
-			return fmt.Errorf("error waiting for EKS Cluster (%s) logging update (%s): %w", d.Id(), updateID, err)
-		}
-	}
-
-	if d.HasChanges("vpc_config.0.endpoint_private_access", "vpc_config.0.endpoint_public_access", "vpc_config.0.public_access_cidrs") {
+	if d.HasChange("vpc_config.0.security_group_ids") {
 		input := &eks.UpdateClusterConfigInput{
 			Name:               aws.String(d.Id()),
-			ResourcesVpcConfig: testAccClusterConfig_expandVPCUpdateRequest(d.Get("vpc_config").([]interface{})),
+			ResourcesVpcConfig: expandVPCSecurityGroupUpdateRequest(d.Get("vpc_config.0.security_group_ids").(*schema.Set)),
 		}
 
-		log.Printf("[DEBUG] Updating EKS Cluster (%s) VPC config: %s", d.Id(), input)
+		log.Printf("[DEBUG] Updating EKS Cluster (%s) security groups: %s", d.Id(), input)
 		output, err := conn.UpdateClusterConfig(input)
 
 		if err != nil {
-			return fmt.Errorf("error updating EKS Cluster (%s) VPC config: %w", d.Id(), err)
+			return fmt.Errorf("error updating EKS Cluster (%s) security groups: %w", d.Id(), err)
 		}
 
 		updateID := aws.StringValue(output.Update.Id)
@@ -705,7 +659,31 @@ func resourceClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 		_, err = waitClusterUpdateSuccessful(conn, d.Id(), updateID, d.Timeout(schema.TimeoutUpdate))
 
 		if err != nil {
-			return fmt.Errorf("error waiting for EKS Cluster (%s) VPC config update (%s): %w", d.Id(), updateID, err)
+			return fmt.Errorf("error waiting for EKS Cluster (%s) security group update (%s): %w", d.Id(), updateID, err)
+		}
+	}
+
+	if d.HasChange("legacy_cluster_params.0.user_data_config") {
+		input := &eks.UpdateClusterUserDataInput{
+			Name: aws.String(d.Id()),
+			UserDataConfig: expandUserDataConfig(
+				d.Get("legacy_cluster_params.0.user_data_config").([]interface{}),
+			),
+		}
+
+		log.Printf("[DEBUG] Updating EKS Cluster (%s) user data: %s", d.Id(), input)
+		output, err := conn.UpdateClusterUserData(input)
+
+		if err != nil {
+			return fmt.Errorf("error updating EKS Cluster (%s) user data: %w", d.Id(), err)
+		}
+
+		updateID := aws.StringValue(output.Update.Id)
+
+		_, err = waitClusterUpdateSuccessful(conn, d.Id(), updateID, d.Timeout(schema.TimeoutUpdate))
+
+		if err != nil {
+			return fmt.Errorf("error waiting for EKS Cluster (%s) user data update (%s): %w", d.Id(), updateID, err)
 		}
 	}
 
@@ -775,50 +753,6 @@ func resourceClusterDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func testAccClusterConfig_expandEncryption(tfList []interface{}) []*eks.EncryptionConfig {
-	if len(tfList) == 0 {
-		return nil
-	}
-
-	var apiObjects []*eks.EncryptionConfig
-
-	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
-
-		if !ok {
-			continue
-		}
-
-		apiObject := &eks.EncryptionConfig{
-			Provider: expandProvider(tfMap["provider"].([]interface{})),
-		}
-
-		if v, ok := tfMap["resources"].(*schema.Set); ok && v.Len() > 0 {
-			apiObject.Resources = flex.ExpandStringSet(v)
-		}
-
-		apiObjects = append(apiObjects, apiObject)
-	}
-
-	return apiObjects
-}
-
-func expandProvider(tfList []interface{}) *eks.Provider {
-	tfMap, ok := tfList[0].(map[string]interface{})
-
-	if !ok {
-		return nil
-	}
-
-	apiObject := &eks.Provider{}
-
-	if v, ok := tfMap["key_arn"].(string); ok && v != "" {
-		apiObject.KeyArn = aws.String(v)
-	}
-
-	return apiObject
-}
-
 func testAccClusterConfig_expandVPCRequest(l []interface{}) *eks.VpcConfigRequest {
 	if len(l) == 0 {
 		return nil
@@ -827,36 +761,17 @@ func testAccClusterConfig_expandVPCRequest(l []interface{}) *eks.VpcConfigReques
 	m := l[0].(map[string]interface{})
 
 	vpcConfigRequest := &eks.VpcConfigRequest{
-		EndpointPrivateAccess: aws.Bool(m["endpoint_private_access"].(bool)),
-		EndpointPublicAccess:  aws.Bool(m["endpoint_public_access"].(bool)),
-		SecurityGroupIds:      flex.ExpandStringSet(m["security_group_ids"].(*schema.Set)),
-		SubnetIds:             flex.ExpandStringSet(m["subnet_ids"].(*schema.Set)),
-	}
-
-	if v, ok := m["public_access_cidrs"].(*schema.Set); ok && v.Len() > 0 {
-		vpcConfigRequest.PublicAccessCidrs = flex.ExpandStringSet(v)
+		SecurityGroupIds: flex.ExpandStringSet(m["security_group_ids"].(*schema.Set)),
+		SubnetIds:        flex.ExpandStringSet(m["subnet_ids"].(*schema.Set)),
 	}
 
 	return vpcConfigRequest
 }
 
-func testAccClusterConfig_expandVPCUpdateRequest(l []interface{}) *eks.VpcConfigRequest {
-	if len(l) == 0 {
-		return nil
+func expandVPCSecurityGroupUpdateRequest(securityGroupIDs *schema.Set) *eks.VpcConfigRequest {
+	return &eks.VpcConfigRequest{
+		SecurityGroupIds: flex.ExpandStringSet(securityGroupIDs),
 	}
-
-	m := l[0].(map[string]interface{})
-
-	vpcConfigRequest := &eks.VpcConfigRequest{
-		EndpointPrivateAccess: aws.Bool(m["endpoint_private_access"].(bool)),
-		EndpointPublicAccess:  aws.Bool(m["endpoint_public_access"].(bool)),
-	}
-
-	if v, ok := m["public_access_cidrs"].(*schema.Set); ok && v.Len() > 0 {
-		vpcConfigRequest.PublicAccessCidrs = flex.ExpandStringSet(v)
-	}
-
-	return vpcConfigRequest
 }
 
 func expandNetworkConfigRequest(tfList []interface{}) *eks.KubernetesNetworkConfigRequest {
@@ -872,32 +787,15 @@ func expandNetworkConfigRequest(tfList []interface{}) *eks.KubernetesNetworkConf
 		apiObject.ServiceIpv4Cidr = aws.String(v)
 	}
 
+	if v, ok := tfMap["pod_ipv4_cidr"].(string); ok && v != "" {
+		apiObject.PodIpv4Cidr = aws.String(v)
+	}
+
 	if v, ok := tfMap["ip_family"].(string); ok && v != "" {
 		apiObject.IpFamily = aws.String(v)
 	}
 
 	return apiObject
-}
-
-func expandLoggingTypes(vEnabledLogTypes *schema.Set) *eks.Logging {
-	vEksLogTypes := []interface{}{}
-	for _, eksLogType := range eks.LogType_Values() {
-		vEksLogTypes = append(vEksLogTypes, eksLogType)
-	}
-	vAllLogTypes := schema.NewSet(schema.HashString, vEksLogTypes)
-
-	return &eks.Logging{
-		ClusterLogging: []*eks.LogSetup{
-			{
-				Enabled: aws.Bool(true),
-				Types:   flex.ExpandStringSet(vEnabledLogTypes),
-			},
-			{
-				Enabled: aws.Bool(false),
-				Types:   flex.ExpandStringSet(vAllLogTypes.Difference(vEnabledLogTypes)),
-			},
-		},
-	}
 }
 
 func expandLegacyClusterParams(tfList []interface{}) *eks.LegacyClusterParamsRequest {
@@ -911,6 +809,10 @@ func expandLegacyClusterParams(tfList []interface{}) *eks.LegacyClusterParamsReq
 	}
 
 	legacyParams := &eks.LegacyClusterParamsRequest{}
+
+	if clusterAutoscalerConfig, ok := tfMap["cluster_autoscaler_config"].([]interface{}); ok && len(clusterAutoscalerConfig) > 0 {
+		legacyParams.ClusterAutoscalerConfig = expandClusterAutoscalerConfig(clusterAutoscalerConfig)
+	}
 
 	if dockerRegistryConfig, ok := tfMap["docker_registry_config"].([]interface{}); ok && len(dockerRegistryConfig) > 0 {
 		legacyParams.DockerRegistryConfig = expandDockerRegistryConfig(dockerRegistryConfig)
@@ -941,6 +843,23 @@ func expandLegacyClusterParams(tfList []interface{}) *eks.LegacyClusterParamsReq
 	}
 
 	return legacyParams
+}
+
+func expandClusterAutoscalerConfig(tfList []interface{}) *eks.ClusterAutoscalerConfig {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	tfMap := tfList[0].(map[string]interface{})
+	config := &eks.ClusterAutoscalerConfig{
+		ClusterAutoscalerRequired: aws.Bool(tfMap["cluster_autoscaler_required"].(bool)),
+	}
+
+	if v, ok := tfMap["cluster_autoscaler_user"].(string); ok && v != "" {
+		config.ClusterAutoscalerUser = aws.String(v)
+	}
+
+	return config
 }
 
 func expandDockerRegistryConfig(tfList []interface{}) *eks.DockerRegistryConfig {
@@ -1139,6 +1058,21 @@ func expandNlbProviderConfig(tfList []interface{}) *eks.NlbProviderConfigRequest
 	return nlbProviderConfig
 }
 
+func expandClusterRemoteAccessConfig(tfList []interface{}) *eks.RemoteAccessConfig {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	tfMap := tfList[0].(map[string]interface{})
+	config := &eks.RemoteAccessConfig{}
+
+	if v, ok := tfMap["ec2_ssh_key"].(string); ok && v != "" {
+		config.Ec2SshKey = aws.String(v)
+	}
+
+	return config
+}
+
 func flattenCertificate(certificate *eks.Certificate) []map[string]interface{} {
 	if certificate == nil {
 		return []map[string]interface{}{}
@@ -1247,6 +1181,7 @@ func flattenNetworkConfig(apiObject *eks.KubernetesNetworkConfigResponse) []inte
 	}
 
 	tfMap := map[string]interface{}{
+		"pod_ipv4_cidr":     aws.StringValue(apiObject.PodIpv4Cidr),
 		"service_ipv4_cidr": aws.StringValue(apiObject.ServiceIpv4Cidr),
 		"ip_family":         aws.StringValue(apiObject.IpFamily),
 	}
@@ -1260,20 +1195,57 @@ func flattenLegacyClusterParams(legacyParams *eks.LegacyClusterParamsResponse) [
 	}
 
 	tfMap := map[string]interface{}{
-		"docker_registry_config": flattenDockerRegistryConfig(legacyParams.DockerRegistryConfig),
-		"ebs_provider_config":    flattenEbsProviderConfig(legacyParams.EbsProviderConfig),
-		"ingress_config":         flattenIngressConfig(legacyParams.IngressConfig),
-		"master_config":          flattenMasterConfig(legacyParams.MasterConfig),
-		"user_data_config":       flattenUserDataConfig(legacyParams.UserDataConfig),
-		"placement_config":       flattenPlacementConfig(legacyParams.PlacementConfig),
-		"nlb_provider_config":    flattenNlbProviderConfig(legacyParams.NlbProviderConfig),
+		"cluster_autoscaler_config": flattenClusterAutoscalerConfig(legacyParams.ClusterAutoscalerConfig),
+		"docker_registry_config":    flattenDockerRegistryConfig(legacyParams.DockerRegistryConfig),
+		"ebs_provider_config":       flattenEbsProviderConfig(legacyParams.EbsProviderConfig),
+		"ingress_config":            flattenIngressConfig(legacyParams.IngressConfig),
+		"master_config":             flattenMasterConfig(legacyParams.MasterConfig),
+		"user_data_config":          flattenUserDataConfig(legacyParams.UserDataConfig),
+		"placement_config":          flattenPlacementConfig(legacyParams.PlacementConfig),
+		"nlb_provider_config":       flattenNlbProviderConfig(legacyParams.NlbProviderConfig),
+	}
+
+	hasConfig := false
+	for _, value := range tfMap {
+		if block, ok := value.([]interface{}); ok && len(block) > 0 {
+			hasConfig = true
+			break
+		}
+	}
+	if !hasConfig {
+		return nil
 	}
 
 	return []interface{}{tfMap}
 }
 
+func flattenClusterAutoscalerConfig(config *eks.ClusterAutoscalerConfig) []interface{} {
+	if config == nil {
+		return nil
+	}
+
+	user := aws.StringValue(config.ClusterAutoscalerUser)
+	if user == "" {
+		user = aws.StringValue(config.ClusterAutoscalerUserName)
+	}
+	if !aws.BoolValue(config.ClusterAutoscalerRequired) && user == "" {
+		return nil
+	}
+
+	return []interface{}{map[string]interface{}{
+		"cluster_autoscaler_required": aws.BoolValue(config.ClusterAutoscalerRequired),
+		"cluster_autoscaler_user":     user,
+	}}
+}
+
 func flattenDockerRegistryConfig(dockerRegistryConfig *eks.DockerRegistryConfig) []interface{} {
 	if dockerRegistryConfig == nil {
+		return nil
+	}
+	if !aws.BoolValue(dockerRegistryConfig.DockerRegistryRequired) &&
+		aws.Int64Value(dockerRegistryConfig.DockerRegistryVolumeIops) == 0 &&
+		aws.Int64Value(dockerRegistryConfig.DockerRegistryVolumeSize) == 0 &&
+		aws.StringValue(dockerRegistryConfig.DockerRegistryVolumeType) == "" {
 		return nil
 	}
 
@@ -1302,10 +1274,17 @@ func flattenEbsProviderConfig(ebsProviderConfig *eks.EbsProviderConfigResponse) 
 	if ebsProviderConfig == nil {
 		return nil
 	}
+	if !aws.BoolValue(ebsProviderConfig.EbsProviderRequired) &&
+		aws.StringValue(ebsProviderConfig.EbsUser) == "" &&
+		aws.StringValue(ebsProviderConfig.EbsUserName) == "" {
+		return nil
+	}
 
 	tfMap := map[string]interface{}{}
 
-	if v := ebsProviderConfig.EbsUserName; v != nil {
+	if v := ebsProviderConfig.EbsUser; v != nil {
+		tfMap["ebs_user"] = aws.StringValue(v)
+	} else if v := ebsProviderConfig.EbsUserName; v != nil {
 		tfMap["ebs_user"] = aws.StringValue(v)
 	}
 
@@ -1318,6 +1297,14 @@ func flattenEbsProviderConfig(ebsProviderConfig *eks.EbsProviderConfigResponse) 
 
 func flattenIngressConfig(ingressConfig *eks.IngressConfig) []interface{} {
 	if ingressConfig == nil {
+		return nil
+	}
+	if !aws.BoolValue(ingressConfig.IngressRequired) &&
+		aws.StringValue(ingressConfig.IngressInstanceType) == "" &&
+		aws.StringValue(ingressConfig.IngressPublicIp) == "" &&
+		aws.Int64Value(ingressConfig.IngressVolumeIops) == 0 &&
+		aws.Int64Value(ingressConfig.IngressVolumeSize) == 0 &&
+		aws.StringValue(ingressConfig.IngressVolumeType) == "" {
 		return nil
 	}
 
@@ -1371,6 +1358,10 @@ func flattenUserDataConfig(userDataConfig *eks.UserDataConfig) []interface{} {
 	if userDataConfig == nil {
 		return nil
 	}
+	if aws.StringValue(userDataConfig.UserData) == "" &&
+		aws.StringValue(userDataConfig.UserDataContentType) == "" {
+		return nil
+	}
 
 	tfMap := map[string]interface{}{
 		"user_data":              aws.StringValue(userDataConfig.UserData),
@@ -1384,10 +1375,17 @@ func flattenNlbProviderConfig(nlbProviderConfig *eks.NlbProviderConfigResponse) 
 	if nlbProviderConfig == nil {
 		return nil
 	}
+	if !aws.BoolValue(nlbProviderConfig.NlbProviderRequired) &&
+		aws.StringValue(nlbProviderConfig.NlbUser) == "" &&
+		aws.StringValue(nlbProviderConfig.NlbUserName) == "" {
+		return nil
+	}
 
 	tfMap := map[string]interface{}{}
 
-	if v := nlbProviderConfig.NlbUserName; v != nil {
+	if v := nlbProviderConfig.NlbUser; v != nil {
+		tfMap["nlb_user"] = aws.StringValue(v)
+	} else if v := nlbProviderConfig.NlbUserName; v != nil {
 		tfMap["nlb_user"] = aws.StringValue(v)
 	}
 
@@ -1398,8 +1396,23 @@ func flattenNlbProviderConfig(nlbProviderConfig *eks.NlbProviderConfigResponse) 
 	return []interface{}{tfMap}
 }
 
+func flattenClusterRemoteAccessConfig(config *eks.RemoteAccessConfig) []interface{} {
+	if config == nil || aws.StringValue(config.Ec2SshKey) == "" {
+		return nil
+	}
+
+	return []interface{}{map[string]interface{}{
+		"ec2_ssh_key": aws.StringValue(config.Ec2SshKey),
+	}}
+}
+
 func flattenPlacementConfig(placementConfig *eks.PlacementConfig) []interface{} {
 	if placementConfig == nil {
+		return nil
+	}
+	if aws.StringValue(placementConfig.Affinity) == "" &&
+		aws.StringValue(placementConfig.HostId) == "" &&
+		(aws.StringValue(placementConfig.Tenancy) == "" || aws.StringValue(placementConfig.Tenancy) == "default") {
 		return nil
 	}
 

--- a/internal/service/eks/cluster_auth_data_source.go
+++ b/internal/service/eks/cluster_auth_data_source.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
 func DataSourceClusterAuth() *schema.Resource {
@@ -29,19 +28,5 @@ func DataSourceClusterAuth() *schema.Resource {
 }
 
 func dataSourceClusterAuthRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*conns.AWSClient).STSConn
-	name := d.Get("name").(string)
-	generator, err := NewGenerator(false, false)
-	if err != nil {
-		return fmt.Errorf("error getting token generator: %w", err)
-	}
-	toke, err := generator.GetWithSTS(name, conn)
-	if err != nil {
-		return fmt.Errorf("error getting token: %w", err)
-	}
-
-	d.SetId(name)
-	d.Set("token", toke.Token)
-
-	return nil
+	return fmt.Errorf("aws_eks_cluster_auth is not supported by Rockit Cloud; use aws_eks_cluster_kubeconfig instead")
 }

--- a/internal/service/eks/errors.go
+++ b/internal/service/eks/errors.go
@@ -36,6 +36,21 @@ func AddonIssuesError(apiObjects []*eks.AddonIssue) error {
 	return errors.ErrorOrNil()
 }
 
+func ClusterIssuesError(apiObjects []*eks.ClusterIssue) error {
+	var errors *multierror.Error
+
+	for _, apiObject := range apiObjects {
+		if apiObject == nil {
+			continue
+		}
+
+		err := awserr.New(aws.StringValue(apiObject.Code), aws.StringValue(apiObject.Message), nil)
+		errors = multierror.Append(errors, fmt.Errorf("%s: %w", strings.Join(aws.StringValueSlice(apiObject.ResourceIds), ", "), err))
+	}
+
+	return errors.ErrorOrNil()
+}
+
 func ErrorDetailError(apiObject *eks.ErrorDetail) error {
 	if apiObject == nil {
 		return nil

--- a/internal/service/eks/k2_unit_test.go
+++ b/internal/service/eks/k2_unit_test.go
@@ -1,0 +1,299 @@
+package eks
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestResourceClusterK2Schema(t *testing.T) {
+	resource := ResourceCluster()
+	if err := resource.InternalValidate(nil, true); err != nil {
+		t.Fatalf("unexpected schema validation error: %s", err)
+	}
+
+	for _, name := range []string{"enabled_cluster_log_types", "encryption_config"} {
+		if field := resource.Schema[name]; !field.Computed || field.Optional {
+			t.Fatalf("%s must be computed-only", name)
+		}
+	}
+
+	vpc := resource.Schema["vpc_config"].Elem.(*schema.Resource).Schema
+	if vpc["security_group_ids"].ForceNew {
+		t.Fatal("security_group_ids must update in place")
+	}
+	for _, name := range []string{"endpoint_private_access", "endpoint_public_access", "public_access_cidrs"} {
+		if field := vpc[name]; !field.Computed || field.Optional {
+			t.Fatalf("vpc_config.%s must be computed-only", name)
+		}
+	}
+
+	legacy := resource.Schema["legacy_cluster_params"].Elem.(*schema.Resource).Schema
+	if !legacy["master_config"].Required {
+		t.Fatal("master_config must be required when legacy_cluster_params is configured")
+	}
+	for blockName, flagName := range map[string]string{
+		"docker_registry_config": "docker_registry_required",
+		"ebs_provider_config":    "ebs_provider_required",
+		"ingress_config":         "ingress_required",
+		"nlb_provider_config":    "nlb_provider_required",
+	} {
+		block := legacy[blockName].Elem.(*schema.Resource).Schema
+		if _, ok := block[flagName]; ok {
+			t.Fatalf("%s must remain implicitly enabled for backward compatibility", flagName)
+		}
+	}
+	userData := legacy["user_data_config"].Elem.(*schema.Resource).Schema
+	if userData["user_data"].ForceNew || userData["user_data_content_type"].ForceNew {
+		t.Fatal("user_data_config fields must update in place")
+	}
+
+	if got := resource.Timeouts.Delete; got == nil || *got != 60*time.Minute {
+		t.Fatalf("cluster delete timeout must match the 60 minute delete retry window, got %v", got)
+	}
+}
+
+func TestExpandAndFlattenK2ClusterConfiguration(t *testing.T) {
+	network := expandNetworkConfigRequest([]interface{}{map[string]interface{}{
+		"ip_family":         "ipv4",
+		"pod_ipv4_cidr":     "10.10.0.0/16",
+		"service_ipv4_cidr": "10.20.0.0/16",
+	}})
+	if got := aws.StringValue(network.PodIpv4Cidr); got != "10.10.0.0/16" {
+		t.Fatalf("unexpected pod CIDR: %q", got)
+	}
+	flattenedNetwork := flattenNetworkConfig(&eks.KubernetesNetworkConfigResponse{
+		PodIpv4Cidr: aws.String("10.10.0.0/16"),
+	})
+	if got := flattenedNetwork[0].(map[string]interface{})["pod_ipv4_cidr"]; got != "10.10.0.0/16" {
+		t.Fatalf("unexpected flattened pod CIDR: %q", got)
+	}
+
+	securityGroups := schema.NewSet(schema.HashString, []interface{}{"sg-1", "sg-2"})
+	vpcUpdate := expandVPCSecurityGroupUpdateRequest(securityGroups)
+	if len(vpcUpdate.SecurityGroupIds) != 2 || vpcUpdate.SubnetIds != nil ||
+		vpcUpdate.EndpointPrivateAccess != nil || vpcUpdate.EndpointPublicAccess != nil ||
+		vpcUpdate.PublicAccessCidrs != nil {
+		t.Fatalf("security group update contains unsupported fields: %#v", vpcUpdate)
+	}
+
+	remoteAccess := expandClusterRemoteAccessConfig([]interface{}{map[string]interface{}{
+		"ec2_ssh_key": "key-name",
+	}})
+	if got := aws.StringValue(remoteAccess.Ec2SshKey); got != "key-name" {
+		t.Fatalf("unexpected SSH key: %q", got)
+	}
+
+	userData := expandUserDataConfig([]interface{}{map[string]interface{}{
+		"user_data":              "#cloud-config",
+		"user_data_content_type": "cloud-config",
+	}})
+	if got := aws.StringValue(userData.UserData); got != "#cloud-config" {
+		t.Fatalf("unexpected user data: %q", got)
+	}
+	if got := aws.StringValue(userData.UserDataContentType); got != "cloud-config" {
+		t.Fatalf("unexpected user data content type: %q", got)
+	}
+	flattenedUserData := flattenUserDataConfig(userData)
+	if got := flattenedUserData[0].(map[string]interface{})["user_data"]; got != "#cloud-config" {
+		t.Fatalf("unexpected flattened user data: %q", got)
+	}
+
+	legacy := expandLegacyClusterParams([]interface{}{map[string]interface{}{
+		"cluster_autoscaler_config": []interface{}{map[string]interface{}{
+			"cluster_autoscaler_required": false,
+			"cluster_autoscaler_user":     "autoscaler",
+		}},
+		"docker_registry_config": []interface{}{map[string]interface{}{
+			"volume_size": 10,
+			"volume_type": "ssd",
+		}},
+		"ebs_provider_config": []interface{}{map[string]interface{}{
+			"ebs_user": "ebs",
+		}},
+		"ingress_config": []interface{}{map[string]interface{}{
+			"instance_type": "small",
+			"volume_size":   10,
+			"volume_type":   "ssd",
+		}},
+		"master_config": []interface{}{map[string]interface{}{
+			"high_availability": false,
+			"instance_type":     "small",
+			"volume_size":       10,
+			"volume_type":       "ssd",
+		}},
+		"nlb_provider_config": []interface{}{map[string]interface{}{
+			"nlb_user": "nlb",
+		}},
+	}})
+
+	if aws.BoolValue(legacy.ClusterAutoscalerConfig.ClusterAutoscalerRequired) {
+		t.Fatal("explicit false Cluster Autoscaler flag was not preserved")
+	}
+	if !aws.BoolValue(legacy.DockerRegistryConfig.DockerRegistryRequired) ||
+		!aws.BoolValue(legacy.EbsProviderConfig.EbsProviderRequired) ||
+		!aws.BoolValue(legacy.IngressConfig.IngressRequired) ||
+		!aws.BoolValue(legacy.NlbProviderConfig.NlbProviderRequired) {
+		t.Fatal("existing integrated services must remain implicitly enabled")
+	}
+
+	flattened := flattenLegacyClusterParams(&eks.LegacyClusterParamsResponse{
+		ClusterAutoscalerConfig: &eks.ClusterAutoscalerConfig{
+			ClusterAutoscalerRequired: aws.Bool(true),
+			ClusterAutoscalerUserName: aws.String("managed-autoscaler"),
+		},
+		EbsProviderConfig: &eks.EbsProviderConfigResponse{
+			EbsProviderRequired: aws.Bool(true),
+			EbsUser:             aws.String("configured-ebs"),
+			EbsUserName:         aws.String("managed-ebs"),
+		},
+	})
+	values := flattened[0].(map[string]interface{})
+	autoscaler := values["cluster_autoscaler_config"].([]interface{})[0].(map[string]interface{})
+	if got := autoscaler["cluster_autoscaler_user"]; got != "managed-autoscaler" {
+		t.Fatalf("unexpected autoscaler user: %q", got)
+	}
+	ebs := values["ebs_provider_config"].([]interface{})[0].(map[string]interface{})
+	if got := ebs["ebs_user"]; got != "configured-ebs" {
+		t.Fatalf("unexpected EBS user: %q", got)
+	}
+
+	emptyLegacy := flattenLegacyClusterParams(&eks.LegacyClusterParamsResponse{
+		ClusterAutoscalerConfig: &eks.ClusterAutoscalerConfig{
+			ClusterAutoscalerRequired: aws.Bool(false),
+		},
+		DockerRegistryConfig: &eks.DockerRegistryConfig{
+			DockerRegistryRequired: aws.Bool(false),
+		},
+		EbsProviderConfig: &eks.EbsProviderConfigResponse{
+			EbsProviderRequired: aws.Bool(false),
+		},
+		IngressConfig: &eks.IngressConfig{
+			IngressRequired: aws.Bool(false),
+		},
+		NlbProviderConfig: &eks.NlbProviderConfigResponse{
+			NlbProviderRequired: aws.Bool(false),
+		},
+		UserDataConfig: &eks.UserDataConfig{},
+		PlacementConfig: &eks.PlacementConfig{
+			Tenancy: aws.String("default"),
+		},
+	})
+	if len(emptyLegacy) != 0 {
+		t.Fatalf("empty API legacy blocks must not create Terraform drift: %#v", emptyLegacy)
+	}
+	if got := flattenClusterRemoteAccessConfig(&eks.RemoteAccessConfig{}); len(got) != 0 {
+		t.Fatalf("empty remote access block must not create Terraform drift: %#v", got)
+	}
+}
+
+func TestResourceNodeGroupK2SchemaAndLabelValidation(t *testing.T) {
+	resource := ResourceNodeGroup()
+	if err := resource.InternalValidate(nil, true); err != nil {
+		t.Fatalf("unexpected schema validation error: %s", err)
+	}
+
+	for _, name := range []string{"force_update_version", "launch_template", "release_version", "version"} {
+		if field := resource.Schema[name]; !field.Computed || field.Optional {
+			t.Fatalf("%s must be computed-only", name)
+		}
+	}
+
+	minSize := resource.Schema["scaling_config"].Elem.(*schema.Resource).Schema["min_size"]
+	if _, errors := minSize.ValidateFunc(0, "min_size"); len(errors) == 0 {
+		t.Fatal("min_size=0 must be rejected")
+	}
+
+	valid := map[string]interface{}{
+		"example.com/name": "value_1",
+		"empty":            "",
+	}
+	if _, errors := validateKubernetesLabels(valid, "labels"); len(errors) != 0 {
+		t.Fatalf("valid labels rejected: %v", errors)
+	}
+
+	invalid := map[string]interface{}{
+		"Bad Prefix/name":  strings.Repeat("x", 64),
+		"bad..prefix/name": "value",
+	}
+	if _, errors := validateKubernetesLabels(invalid, "labels"); len(errors) < 3 {
+		t.Fatalf("invalid labels were not fully rejected: %v", errors)
+	}
+}
+
+func TestClusterAuthIsExplicitlyUnsupported(t *testing.T) {
+	err := dataSourceClusterAuthRead(nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "aws_eks_cluster_kubeconfig") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestK2FailureDetailsAreActionable(t *testing.T) {
+	clusterErr := ClusterIssuesError([]*eks.ClusterIssue{{
+		Code:        aws.String("InsufficientCapacity"),
+		Message:     aws.String("control plane could not be provisioned"),
+		ResourceIds: aws.StringSlice([]string{"cluster/test"}),
+	}})
+	if clusterErr == nil ||
+		!strings.Contains(clusterErr.Error(), "InsufficientCapacity") ||
+		!strings.Contains(clusterErr.Error(), "control plane could not be provisioned") {
+		t.Fatalf("cluster health details were lost: %v", clusterErr)
+	}
+
+	updateErr := ErrorDetailsError([]*eks.ErrorDetail{{
+		ErrorCode:    aws.String("InvalidParameter"),
+		ErrorMessage: aws.String("security group update was rejected"),
+		ResourceIds:  aws.StringSlice([]string{"sg-test"}),
+	}})
+	if updateErr == nil ||
+		!strings.Contains(updateErr.Error(), "InvalidParameter") ||
+		!strings.Contains(updateErr.Error(), "security group update was rejected") {
+		t.Fatalf("update failure details were lost: %v", updateErr)
+	}
+}
+
+func TestClusterUpdateFallsBackWhenDescribeUpdateIsUnavailable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/clusters/test/updates/update-1":
+			w.Header().Set("X-Amzn-Errortype", "PathNotFoundError")
+			http.Error(w, `{"message":"Specified path does not exist."}`, http.StatusBadRequest)
+		case "/clusters/test":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"cluster":{"name":"test","status":"READY"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	conn := eks.New(session.Must(session.NewSession(&aws.Config{
+		Credentials: credentials.NewStaticCredentials("test", "test", ""),
+		Endpoint:    aws.String(server.URL),
+		Region:      aws.String("ru-msk"),
+	})))
+
+	update, err := waitClusterUpdateSuccessful(conn, "test", "update-1", 5*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected fallback waiter error: %s", err)
+	}
+	if got := aws.StringValue(update.Status); got != eks.UpdateStatusSuccessful {
+		t.Fatalf("unexpected fallback update status: %q", got)
+	}
+
+	update, err = waitClusterUpdateSuccessful(conn, "test", "", 5*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected empty update ID fallback error: %s", err)
+	}
+	if got := aws.StringValue(update.Status); got != eks.UpdateStatusSuccessful {
+		t.Fatalf("unexpected empty ID fallback update status: %q", got)
+	}
+}

--- a/internal/service/eks/node_group.go
+++ b/internal/service/eks/node_group.go
@@ -2,8 +2,11 @@ package eks
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"reflect"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -25,6 +28,60 @@ import (
 const (
 	nodeGroupCreateRetryTimeout = 15 * time.Minute
 )
+
+var (
+	kubernetesLabelNameRegexp   = regexp.MustCompile(`^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$`)
+	kubernetesLabelPrefixRegexp = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+)
+
+func validateKubernetesLabels(i interface{}, k string) ([]string, []error) {
+	labels, ok := i.(map[string]interface{})
+	if !ok {
+		return nil, []error{fmt.Errorf("%q must be a map of strings", k)}
+	}
+
+	var errors []error
+	for key, rawValue := range labels {
+		name := key
+		if strings.Count(key, "/") > 1 {
+			errors = append(errors, fmt.Errorf("%q key %q must contain at most one slash", k, key))
+		}
+		if slash := strings.LastIndex(key, "/"); slash >= 0 {
+			prefix := key[:slash]
+			name = key[slash+1:]
+			if !validKubernetesLabelPrefix(prefix) {
+				errors = append(errors, fmt.Errorf("%q key %q must have a valid DNS prefix between 1 and 253 characters", k, key))
+			}
+		}
+
+		if len(name) == 0 || len(name) > 63 || !kubernetesLabelNameRegexp.MatchString(name) {
+			errors = append(errors, fmt.Errorf("%q key %q must have a valid name of at most 63 characters", k, key))
+		}
+
+		value, ok := rawValue.(string)
+		if !ok {
+			errors = append(errors, fmt.Errorf("%q value for key %q must be a string", k, key))
+			continue
+		}
+		if len(value) > 63 || (value != "" && !kubernetesLabelNameRegexp.MatchString(value)) {
+			errors = append(errors, fmt.Errorf("%q value for key %q must be empty or a valid label value of at most 63 characters", k, key))
+		}
+	}
+
+	return nil, errors
+}
+
+func validKubernetesLabelPrefix(prefix string) bool {
+	if len(prefix) == 0 || len(prefix) > 253 {
+		return false
+	}
+	for _, label := range strings.Split(prefix, ".") {
+		if len(label) == 0 || len(label) > 63 || !kubernetesLabelPrefixRegexp.MatchString(label) {
+			return false
+		}
+	}
+	return true
+}
 
 func ResourceNodeGroup() *schema.Resource {
 	return &schema.Resource{
@@ -77,47 +134,41 @@ func ResourceNodeGroup() *schema.Resource {
 			},
 			"force_update_version": {
 				Type:     schema.TypeBool,
-				Optional: true,
+				Computed: true,
 			},
 			"instance_types": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				MinItems: 1,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
 			},
 			"labels": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:         schema.TypeMap,
+				Optional:     true,
+				ValidateFunc: validateKubernetesLabels,
+				Elem:         &schema.Schema{Type: schema.TypeString},
 			},
 			"launch_template": {
 				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Computed: true, // FIXME: remove after launch_template is supported in C2 EKS API.
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
-							Type:          schema.TypeString,
-							Optional:      true,
-							Computed:      true,
-							ForceNew:      true,
-							ConflictsWith: []string{"launch_template.0.name"},
-							ValidateFunc:  verify.ValidLaunchTemplateID,
+							Type:     schema.TypeString,
+							Computed: true,
 						},
 						"name": {
-							Type:          schema.TypeString,
-							Optional:      true,
-							Computed:      true,
-							ForceNew:      true,
-							ConflictsWith: []string{"launch_template.0.id"},
-							ValidateFunc:  verify.ValidLaunchTemplateName,
+							Type:     schema.TypeString,
+							Computed: true,
 						},
 						"version": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringLenBetween(1, 255),
+							Type:     schema.TypeString,
+							Computed: true,
 						},
 					},
 				},
@@ -143,7 +194,6 @@ func ResourceNodeGroup() *schema.Resource {
 			},
 			"release_version": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"remote_access": {
@@ -210,7 +260,7 @@ func ResourceNodeGroup() *schema.Resource {
 						"min_size": {
 							Type:         schema.TypeInt,
 							Required:     true,
-							ValidateFunc: validation.IntAtLeast(0),
+							ValidateFunc: validation.IntAtLeast(1),
 						},
 					},
 				},
@@ -282,7 +332,6 @@ func ResourceNodeGroup() *schema.Resource {
 			},
 			"version": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 		},
@@ -326,14 +375,6 @@ func resourceNodeGroupCreate(ctx context.Context, d *schema.ResourceData, meta i
 		input.Labels = flex.ExpandStringMap(v)
 	}
 
-	if v := d.Get("launch_template").([]interface{}); len(v) > 0 {
-		input.LaunchTemplate = expandLaunchTemplateSpecification(v)
-	}
-
-	if v, ok := d.GetOk("release_version"); ok {
-		input.ReleaseVersion = aws.String(v.(string))
-	}
-
 	if v := d.Get("remote_access").([]interface{}); len(v) > 0 {
 		input.RemoteAccess = expandRemoteAccessConfig(v)
 	}
@@ -348,10 +389,6 @@ func resourceNodeGroupCreate(ctx context.Context, d *schema.ResourceData, meta i
 
 	if v, ok := d.GetOk("update_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		input.UpdateConfig = expandNodegroupUpdateConfig(v.([]interface{})[0].(map[string]interface{}))
-	}
-
-	if v, ok := d.GetOk("version"); ok {
-		input.Version = aws.String(v.(string))
 	}
 
 	if len(tags) > 0 {
@@ -502,59 +539,6 @@ func resourceNodeGroupUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 
-	// Do any version update first.
-	if d.HasChanges("launch_template", "release_version", "version") {
-		input := &eks.UpdateNodegroupVersionInput{
-			ClientRequestToken: aws.String(resource.UniqueId()),
-			ClusterName:        aws.String(clusterName),
-			Force:              aws.Bool(d.Get("force_update_version").(bool)),
-			NodegroupName:      aws.String(nodeGroupName),
-		}
-
-		if v := d.Get("launch_template").([]interface{}); len(v) > 0 {
-			input.LaunchTemplate = expandLaunchTemplateSpecification(v)
-
-			// When returning Launch Template information, the API returns all
-			// fields. Since both the id and name are saved to the Terraform
-			// state for drift detection and the API returns the following
-			// error if both are present during update:
-			// InvalidParameterException: Either provide launch template ID or launch template name in the request.
-
-			// Remove the name if there are no changes, to prefer the ID.
-			if input.LaunchTemplate.Id != nil && input.LaunchTemplate.Name != nil && !d.HasChange("launch_template.0.name") {
-				input.LaunchTemplate.Name = nil
-			}
-
-			// Otherwise, remove the ID, but only if both are present still.
-			if input.LaunchTemplate.Id != nil && input.LaunchTemplate.Name != nil && !d.HasChange("launch_template.0.id") {
-				input.LaunchTemplate.Id = nil
-			}
-		}
-
-		if v, ok := d.GetOk("release_version"); ok && d.HasChange("release_version") {
-			input.ReleaseVersion = aws.String(v.(string))
-		}
-
-		if v, ok := d.GetOk("version"); ok && d.HasChange("version") {
-			input.Version = aws.String(v.(string))
-		}
-
-		output, err := conn.UpdateNodegroupVersion(input)
-
-		if err != nil {
-			return diag.Errorf("error updating EKS Node Group (%s) version: %s", d.Id(), err)
-		}
-
-		updateID := aws.StringValue(output.Update.Id)
-
-		// FIXME: Use waitNodegroupUpdateSuccessful after DescribeUpdate implementation in C2.
-		_, err = waitC2NodegroupUpdated(ctx, conn, clusterName, nodeGroupName, d.Timeout(schema.TimeoutUpdate))
-
-		if err != nil {
-			return diag.Errorf("error waiting for EKS Node Group (%s) version update (%s): %s", d.Id(), updateID, err)
-		}
-	}
-
 	if d.HasChanges("labels", "scaling_config", "taint", "update_config") {
 		oldLabelsRaw, newLabelsRaw := d.GetChange("labels")
 		oldTaintsRaw, newTaintsRaw := d.GetChange("taint")
@@ -587,8 +571,7 @@ func resourceNodeGroupUpdate(ctx context.Context, d *schema.ResourceData, meta i
 
 		updateID := aws.StringValue(output.Update.Id)
 
-		// FIXME: Use waitNodegroupUpdateSuccessful after DescribeUpdate implementation in C2.
-		_, err = waitC2NodegroupUpdated(ctx, conn, clusterName, nodeGroupName, d.Timeout(schema.TimeoutUpdate))
+		_, err = waitNodegroupUpdateSuccessful(ctx, conn, clusterName, nodeGroupName, updateID, d.Timeout(schema.TimeoutUpdate))
 
 		if err != nil {
 			return diag.Errorf("error waiting for EKS Node Group (%s) config update (%s): %s", d.Id(), updateID, err)
@@ -638,30 +621,6 @@ func resourceNodeGroupDelete(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	return nil
-}
-
-func expandLaunchTemplateSpecification(l []interface{}) *eks.LaunchTemplateSpecification {
-	if len(l) == 0 || l[0] == nil {
-		return nil
-	}
-
-	m := l[0].(map[string]interface{})
-
-	config := &eks.LaunchTemplateSpecification{}
-
-	if v, ok := m["id"].(string); ok && v != "" {
-		config.Id = aws.String(v)
-	}
-
-	if v, ok := m["name"].(string); ok && v != "" {
-		config.Name = aws.String(v)
-	}
-
-	if v, ok := m["version"].(string); ok && v != "" {
-		config.Version = aws.String(v)
-	}
-
-	return config
 }
 
 func expandNodegroupScalingConfig(tfMap map[string]interface{}) *eks.NodegroupScalingConfig {

--- a/internal/service/eks/status.go
+++ b/internal/service/eks/status.go
@@ -62,7 +62,7 @@ func statusClusterUpdate(conn *eks.EKS, name, id string) resource.StateRefreshFu
 		output, err := FindClusterUpdateByNameAndID(conn, name, id)
 
 		if tfresource.NotFound(err) {
-			return nil, "", nil
+			return nil, eks.UpdateStatusInProgress, nil
 		}
 
 		if err != nil {
@@ -110,7 +110,7 @@ func statusNodegroupUpdate(conn *eks.EKS, clusterName, nodeGroupName, id string)
 		output, err := FindNodegroupUpdateByClusterNameNodegroupNameAndID(conn, clusterName, nodeGroupName, id)
 
 		if tfresource.NotFound(err) {
-			return nil, "", nil
+			return nil, eks.UpdateStatusInProgress, nil
 		}
 
 		if err != nil {

--- a/internal/service/eks/wait.go
+++ b/internal/service/eks/wait.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
@@ -90,6 +91,10 @@ func waitClusterCreated(conn *eks.EKS, name string, timeout time.Duration) (*eks
 	outputRaw, err := stateConf.WaitForState()
 
 	if output, ok := outputRaw.(*eks.Cluster); ok {
+		if status, health := aws.StringValue(output.Status), output.Health; status == eks.ClusterStatusFailed && health != nil {
+			tfresource.SetLastError(err, ClusterIssuesError(health.Issues))
+		}
+
 		return output, err
 	}
 
@@ -98,7 +103,16 @@ func waitClusterCreated(conn *eks.EKS, name string, timeout time.Duration) (*eks
 
 func waitClusterDeleted(conn *eks.EKS, name string, timeout time.Duration) (*eks.Cluster, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending:        []string{eks.ClusterStatusPending, eks.ClusterStatusClaimed, eks.ClusterStatusDeleting},
+		Pending: []string{
+			eks.ClusterStatusActive,
+			eks.ClusterStatusClaimed,
+			eks.ClusterStatusCreating,
+			eks.ClusterStatusDeleting,
+			eks.ClusterStatusPending,
+			eks.ClusterStatusProvisioning,
+			eks.ClusterStatusReady,
+			eks.ClusterStatusUpdating,
+		},
 		Target:         []string{eks.ClusterStatusDeleted},
 		Refresh:        statusCluster(conn, name),
 		Timeout:        timeout,
@@ -112,6 +126,10 @@ func waitClusterDeleted(conn *eks.EKS, name string, timeout time.Duration) (*eks
 	}
 
 	if output, ok := outputRaw.(*eks.Cluster); ok {
+		if status, health := aws.StringValue(output.Status), output.Health; status == eks.ClusterStatusFailed && health != nil {
+			tfresource.SetLastError(err, ClusterIssuesError(health.Issues))
+		}
+
 		return output, err
 	}
 
@@ -119,6 +137,16 @@ func waitClusterDeleted(conn *eks.EKS, name string, timeout time.Duration) (*eks
 }
 
 func waitClusterUpdateSuccessful(conn *eks.EKS, name, id string, timeout time.Duration) (*eks.Update, error) { //nolint:unparam
+	if id == "" {
+		if _, err := waitClusterReadyAfterUpdate(conn, name, timeout); err != nil {
+			return nil, err
+		}
+
+		return &eks.Update{
+			Status: aws.String(eks.UpdateStatusSuccessful),
+		}, nil
+	}
+
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{eks.UpdateStatusInProgress},
 		Target:  []string{eks.UpdateStatusSuccessful},
@@ -127,10 +155,48 @@ func waitClusterUpdateSuccessful(conn *eks.EKS, name, id string, timeout time.Du
 	}
 
 	outputRaw, err := stateConf.WaitForState()
+	if tfawserr.ErrCodeEquals(err, "PathNotFoundError") {
+		if _, fallbackErr := waitClusterReadyAfterUpdate(conn, name, timeout); fallbackErr != nil {
+			return nil, fallbackErr
+		}
+
+		return &eks.Update{
+			Id:     aws.String(id),
+			Status: aws.String(eks.UpdateStatusSuccessful),
+		}, nil
+	}
 
 	if output, ok := outputRaw.(*eks.Update); ok {
 		if status := aws.StringValue(output.Status); status == eks.UpdateStatusCancelled || status == eks.UpdateStatusFailed {
 			tfresource.SetLastError(err, ErrorDetailsError(output.Errors))
+		}
+
+		return output, err
+	}
+
+	return nil, err
+}
+
+func waitClusterReadyAfterUpdate(conn *eks.EKS, name string, timeout time.Duration) (*eks.Cluster, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			eks.ClusterStatusActive,
+			eks.ClusterStatusClaimed,
+			eks.ClusterStatusCreating,
+			eks.ClusterStatusPending,
+			eks.ClusterStatusProvisioning,
+			eks.ClusterStatusUpdating,
+		},
+		Target:  []string{eks.ClusterStatusReady},
+		Refresh: statusCluster(conn, name),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*eks.Cluster); ok {
+		if status, health := aws.StringValue(output.Status), output.Health; status == eks.ClusterStatusFailed && health != nil {
+			tfresource.SetLastError(err, ClusterIssuesError(health.Issues))
 		}
 
 		return output, err
@@ -175,7 +241,7 @@ func waitFargateProfileDeleted(conn *eks.EKS, clusterName, fargateProfileName st
 
 func waitNodegroupCreated(ctx context.Context, conn *eks.EKS, clusterName, nodeGroupName string, timeout time.Duration) (*eks.Nodegroup, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{eks.NodegroupStatusClaimed, eks.NodegroupStatusPending, eks.NodegroupStatusCreating},
+		Pending: []string{eks.NodegroupStatusClaimed, eks.NodegroupStatusPending, eks.NodegroupStatusCreating, eks.NodegroupStatusProvisioning},
 		Target:  []string{eks.NodegroupStatusActive},
 		Refresh: statusNodegroup(conn, clusterName, nodeGroupName),
 		Timeout: timeout,
@@ -184,7 +250,7 @@ func waitNodegroupCreated(ctx context.Context, conn *eks.EKS, clusterName, nodeG
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
 	if output, ok := outputRaw.(*eks.Nodegroup); ok {
-		if status, health := aws.StringValue(output.Status), output.Health; status == eks.NodegroupStatusCreateFailed && health != nil {
+		if status, health := aws.StringValue(output.Status), output.Health; (status == eks.NodegroupStatusCreateFailed || status == eks.NodegroupStatusDegraded) && health != nil {
 			tfresource.SetLastError(err, IssuesError(health.Issues))
 		}
 
@@ -196,7 +262,16 @@ func waitNodegroupCreated(ctx context.Context, conn *eks.EKS, clusterName, nodeG
 
 func waitNodegroupDeleted(ctx context.Context, conn *eks.EKS, clusterName, nodeGroupName string, timeout time.Duration) (*eks.Nodegroup, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending:        []string{eks.NodegroupStatusClaimed, eks.NodegroupStatusPending, eks.NodegroupStatusDeleting},
+		Pending: []string{
+			eks.NodegroupStatusActive,
+			eks.NodegroupStatusClaimed,
+			eks.NodegroupStatusCreateFailed,
+			eks.NodegroupStatusDegraded,
+			eks.NodegroupStatusDeleting,
+			eks.NodegroupStatusPending,
+			eks.NodegroupStatusProvisioning,
+			eks.NodegroupStatusUpdating,
+		},
 		Target:         []string{eks.NodegroupStatusDeleted},
 		Refresh:        statusNodegroup(conn, clusterName, nodeGroupName),
 		Timeout:        timeout,
@@ -220,27 +295,6 @@ func waitNodegroupDeleted(ctx context.Context, conn *eks.EKS, clusterName, nodeG
 	return nil, err
 }
 
-// This is a temporary solution for C2 Nodegroups until DescribeUpdate is implemented.
-//
-//nolint:unparam // A waiter return value should include an object (*eks.Nodegroup) even if it is never used.
-func waitC2NodegroupUpdated(ctx context.Context, conn *eks.EKS, clusterName, nodeGroupName string, timeout time.Duration) (*eks.Nodegroup, error) {
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{eks.NodegroupStatusClaimed, eks.NodegroupStatusPending, eks.NodegroupStatusUpdating},
-		Target:  []string{eks.NodegroupStatusActive},
-		Refresh: statusNodegroup(conn, clusterName, nodeGroupName),
-		Timeout: timeout,
-	}
-
-	outputRaw, err := stateConf.WaitForStateContext(ctx)
-
-	if output, ok := outputRaw.(*eks.Nodegroup); ok {
-		return output, err
-	}
-
-	return nil, err
-}
-
-//lint:ignore U1000 Ignore unused function temporarily
 func waitNodegroupUpdateSuccessful(ctx context.Context, conn *eks.EKS, clusterName, nodeGroupName, id string, timeout time.Duration) (*eks.Update, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{eks.UpdateStatusInProgress},


### PR DESCRIPTION
Related with https://github.com/C2Devel/aws-sdk-go/pull/68 

```release-note:enhancement
resource/aws_eks_cluster: Add K2Cloud Pod CIDR, remote access, Cluster Autoscaler, in-place security group updates, and in-place user-data updates
```

```release-note:enhancement
resource/aws_eks_cluster: Propagate K2Cloud health and update failures from waiters and align delete timeouts
```

```release-note:enhancement
resource/aws_eks_node_group: Reject unsupported version and custom launch-template inputs while preserving platform-managed launch-template state
```

```release-note:enhancement
data-source/aws_eks_cluster_auth: Return an actionable error directing K2Cloud users to `aws_eks_cluster_kubeconfig`
```