### PR TITLE
Bump aws-sdk-go to v1.44.10-ROCKIT22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/hashicorp/terraform-provider-aws
 
 go 1.21
 
-replace github.com/aws/aws-sdk-go => github.com/C2Devel/aws-sdk-go v1.44.10-ROCKIT21
+replace github.com/aws/aws-sdk-go => github.com/C2Devel/aws-sdk-go v1.44.10-ROCKIT22
 
 require (
 	github.com/ProtonMail/go-crypto v1.1.0-alpha.2

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/C2Devel/aws-sdk-go v1.44.10-ROCKIT21 h1:SFhVNWUFxHA9/nAlBM1lDQ6t+axnQSbR8rlkafjv0lc=
-github.com/C2Devel/aws-sdk-go v1.44.10-ROCKIT21/go.mod h1:JCfES7rKS8ADm4DcmGHd2i0vL86B2b6rpVPkniCtJX8=
+github.com/C2Devel/aws-sdk-go v1.44.10-ROCKIT22 h1:z8p/r+2DiLfCJmt3nwUDIqahV7xYG/YJTBblMEfETgA=
+github.com/C2Devel/aws-sdk-go v1.44.10-ROCKIT22/go.mod h1:JCfES7rKS8ADm4DcmGHd2i0vL86B2b6rpVPkniCtJX8=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97LyUpzH9P6Hrlg=


### PR DESCRIPTION
Bump aws-sdk-go to v1.44.10-ROCKIT22
- aws-sdk-go module is updated to v1.44.10-ROCKIT22